### PR TITLE
docs: add Automation Station community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ bash tests/test-e2e.sh
 
 Based on [agentic-ai-sdlc-wizard](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard) v1.31.0. Same SDLC philosophy, translated to Codex's Bash-only tool model (~70% parity).
 
+## Community
+
+Come join **[Automation Station](https://discord.com/invite/fGPEF7GHrF)** — a community Discord packed with software engineers bringing 40+ years of combined experience across every area of the stack (frontend, backend, infra, embedded, data, QA, DevOps, you name it). Share patterns, ask questions, compare notes on AI agents, automation, and SDLC tooling.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Adds a **Community** section to the README linking to the Automation Station Discord
- Mirrors the same section added to upstream sdlc-wizard
- Placed between Upstream and License

## Test plan
- [x] README renders correctly (markdown formatting preserved)
- [x] Link to Discord verified