### PR TITLE
test(e2e): make real Codex sessions opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ bash tests/test-adapter.sh
 bash tests/test-setup.sh
 bash tests/test-update.sh
 
-# E2E tests (requires codex CLI + auth, costs tokens)
-bash tests/test-e2e.sh
+# E2E tests (opt-in: requires codex CLI + auth, consumes tokens)
+CODEX_E2E=1 bash tests/test-e2e.sh
 ```
 
 - Release contract tests for semver tags, GitHub Releases, and README release docs
@@ -280,7 +280,7 @@ bash tests/test-e2e.sh
 - Skill packaging tests for SKILL.md, agents/openai.yaml, and dual-distribution docs
 - npm packaging smoke tests for package metadata, packed contents, and npm exec
 - Adapter, setup, and update tests for the Codex-specific behavior surface
-- E2E integration tests for real Codex sessions proving hooks fire
+- E2E integration tests are token-consuming and opt-in; use `CODEX_E2E=1 bash tests/test-e2e.sh` when you explicitly want real Codex sessions proving hooks fire
 
 ## Upstream
 

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -747,6 +747,16 @@ test_readme_mentions_npx_entrypoint() {
     fi
 }
 
+test_e2e_requires_explicit_token_opt_in() {
+    if grep -q 'CODEX_E2E:-0' "$REPO_DIR/tests/test-e2e.sh" \
+        && grep -q 'CODEX_E2E=1 bash tests/test-e2e.sh' "$REPO_DIR/README.md" \
+        && grep -qi 'token-consuming' "$REPO_DIR/README.md"; then
+        pass "E2E tests require explicit token-consuming opt-in"
+    else
+        fail "E2E tests should be opt-in so normal verification does not consume tokens"
+    fi
+}
+
 test_pretool_blocks_commit
 test_pretool_blocks_push
 test_pretool_allows_safe_command
@@ -780,6 +790,7 @@ test_package_cli_help_mentions_update
 test_package_cli_runs_check_command
 test_package_cli_runs_update_command
 test_readme_mentions_npx_entrypoint
+test_e2e_requires_explicit_token_opt_in
 
 echo ""
 echo "=== Results: $PASSED passed, $FAILED failed ==="

--- a/tests/test-e2e.sh
+++ b/tests/test-e2e.sh
@@ -10,6 +10,7 @@ REPO_DIR="$SCRIPT_DIR/.."
 PASSED=0
 FAILED=0
 SKIPPED=0
+CODEX_E2E="${CODEX_E2E:-0}"
 CODEX_E2E_MODEL="${CODEX_E2E_MODEL:-gpt-5.5}"
 
 RED='\033[0;31m'
@@ -20,6 +21,13 @@ NC='\033[0m'
 pass() { echo -e "${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
 fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
 skip() { echo -e "${YELLOW}SKIP${NC}: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+if [ "$CODEX_E2E" != "1" ]; then
+    skip "E2E: real Codex sessions are token-consuming; set CODEX_E2E=1 to run"
+    echo ""
+    echo "=== E2E Results: $PASSED passed, $FAILED failed, $SKIPPED skipped ==="
+    exit 0
+fi
 
 codex_transport_unavailable() {
     echo "$1" | grep -Eqi 'failed to lookup address|failed to connect to websocket|stream disconnected before completion|api\.openai\.com'

--- a/tests/test-e2e.sh
+++ b/tests/test-e2e.sh
@@ -59,9 +59,10 @@ setup_workspace() {
     local ws
     ws=$(mktemp -d)
     git init "$ws" >/dev/null 2>&1
-    git -C "$ws" config user.email "codex-sdlc-e2e@example.invalid"
     git -C "$ws" config user.name "Codex SDLC E2E"
-    (cd "$ws" && git commit --allow-empty -m "init" >/dev/null 2>&1)
+    git -C "$ws" config user.email "codex-sdlc-e2e@example.invalid"
+    git -C "$ws" commit --allow-empty -m "init" >/dev/null 2>&1
+    git -C "$ws" rev-parse --verify HEAD >/dev/null 2>&1
     (cd "$ws" && bash "$REPO_DIR/install.sh" >/dev/null 2>&1)
     echo "$ws"
 }


### PR DESCRIPTION
## Summary
- harden E2E temp repo setup with local Git identity and a verified initial HEAD
- make real Codex CLI E2E token-consuming tests opt-in via CODEX_E2E=1
- document the opt-in command and add a regression test so default verification stays token-free

## Verification
- bash tests/test-adapter.sh
- bash tests/test-update.sh
- bash tests/test-setup.sh
- bash tests/test-e2e.sh (default skip, no tokens)