### PR TITLE
chore: release 0.7.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Generic npm entrypoint examples: `npx codex-sdlc-wizard`, `npx codex-sdlc-wizard
 Useful follow-ups after install:
 
 ```bash
-npx codex-sdlc-wizard@0.7.13 check
-npx codex-sdlc-wizard@0.7.13 update
+npx codex-sdlc-wizard@0.7.14 check
+npx codex-sdlc-wizard@0.7.14 update
 ```
 
 If you want pinned release examples instead of `@latest`, see [Releases](#releases).
@@ -85,10 +85,10 @@ How to choose:
 
 ```bash
 # recommended interactive bootstrap path
-npx codex-sdlc-wizard@0.7.13 --model-profile maximum
+npx codex-sdlc-wizard@0.7.14 --model-profile maximum
 
 # interactive bootstrap with the efficiency-first profile if you already know you want it
-npx codex-sdlc-wizard@0.7.13 --model-profile mixed
+npx codex-sdlc-wizard@0.7.14 --model-profile mixed
 
 # floating latest release with the same bootstrap recommendation
 npx codex-sdlc-wizard@latest --model-profile maximum
@@ -190,7 +190,7 @@ If you are consuming this repo in a real project, prefer a tagged release over `
 
 ```bash
 # npm / npx pinned to the current release
-npx codex-sdlc-wizard@0.7.13
+npx codex-sdlc-wizard@0.7.14
 
 # npm / npx floating on the newest published release
 npx codex-sdlc-wizard@latest
@@ -200,7 +200,7 @@ npx codex-sdlc-wizard@latest
 # so $codex-sdlc-wizard is available inside Codex
 
 # git-based install
-git clone --branch v0.7.13 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
+git clone --branch v0.7.14 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
 ```
 
 ### Maintainer Release Flow

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- `codex-sdlc-wizard@0.7.13` and `v0.7.13` are the current release target for canonical `$sdlc` naming/display hardening discovered during real consumer setup
+- `codex-sdlc-wizard@0.7.14` and `v0.7.14` are the current release target for token-free normal regression tests after making real Codex E2E sessions opt-in
 - npm trusted publishing is configured and the GitHub release workflow is now proven for real OIDC publish
 - the repo now ships both a Codex skill package (`SKILL.md`, `agents/openai.yaml`) and the installer/setup adapter (`install.sh`, `setup.sh`)
 - the npm CLI now defaults to adaptive interactive setup instead of requiring an explicit `setup` subcommand for the main human path
@@ -30,12 +30,12 @@
 
 ## Next Release Cycle
 
-### 0.7.14
+### 0.7.15
 
-Purpose: continue proving the post-`0.7.13` consumer path on real repos and stabilize any reusable wizard bugs without changing the default-use claim early.
+Purpose: continue proving the post-`0.7.14` consumer path on real repos and stabilize any reusable wizard bugs without changing the default-use claim early.
 
 Scope:
-- run `0.7.13` on 3-5 pilot repos and log results in `benchmarks/pilot-rollout.csv`
+- run `0.7.14` on 3-5 pilot repos and log results in `benchmarks/pilot-rollout.csv`
 - cut a stabilization patch only if pilots surface another reusable wizard bug
 - keep the default-use recommendation gated on the measurable pilot summary
 - keep separate model-profile measurement running, but do not let it block pilot rollout work
@@ -45,11 +45,11 @@ Scope:
 The issue tracker is currently clear.
 
 - open a new issue only when pilot consumption exposes a proven reusable wizard bug
-- avoid speculative backlog churn while `0.7.13` is being consumed on real repos
+- avoid speculative backlog churn while `0.7.14` is being consumed on real repos
 
 ## Remaining Backlog
 
-After `0.7.13`, the main backlog is:
+After `0.7.14`, the main backlog is:
 
 - pilot rollout proof for default use on real repos
 - any reusable wizard fixes discovered during the pilot set
@@ -59,15 +59,15 @@ After `0.7.13`, the main backlog is:
 
 ## Working Order
 
-1. Prove the default-use gate on 3-5 pilot repos with `0.7.13`
-2. Ship `0.7.14` only if pilot rollout surfaces another reusable wizard bug
+1. Prove the default-use gate on 3-5 pilot repos with `0.7.14`
+2. Ship `0.7.15` only if pilot rollout surfaces another reusable wizard bug
 3. Keep creator-tool investigation behind the active backlog
 
 ## Default-Use Gate
 
 Before calling this the default Codex SDLC path, prove it on real pilot repos instead of just repo-self-tests.
 
-- run `0.7.13` on 3-5 pilot repos
+- run `0.7.14` on 3-5 pilot repos
 - require pilot success >= 95% before default use
 - allow no more than 1 reusable wizard bug across the pilot set
 - track the pilot set in `benchmarks/pilot-rollout.csv`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-sdlc-wizard",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Codex SDLC adaptive setup wizard and maintenance CLI for npx distribution",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release v0.7.14 after PR #19 so the token-free default regression path is available via npm.\n\nProof run from clean origin/main worktree:\n- bash tests/test-release.sh\n- bash tests/test-roadmap.sh\n- bash tests/test-packaging.sh\n- bash tests/test-npm.sh\n- bash tests/test-skill.sh\n- bash tests/test-adapter.sh\n- bash tests/test-setup.sh\n- bash tests/test-update.sh\n- bash tests/test-e2e.sh (default token-free path: skipped as expected)\n- git diff --check