### PR TITLE
docs(setup): add Codex Desktop handoff guidance

### DIFF
--- a/SDLC-LOOP.md
+++ b/SDLC-LOOP.md
@@ -37,3 +37,21 @@ For setup, installs, PATH repair, and auth-heavy workflows:
 - Capture before/after evidence.
 - Re-run the bootstrap or health check after each fix.
 - Treat the health check as the prove-it gate.
+
+## Codex Desktop handoff
+
+Use Codex Desktop handoff when setup crosses a browser, desktop app, admin portal, screenshot, or auth window that CLI cannot see. Codex Desktop is available on macOS and Windows.
+
+From the repo root:
+
+```bash
+codex app .
+```
+
+Computer-use work must report back as evidence, not just chat. Prefer a repo-local `.reviews/desktop-computer-use-report.md` or equivalent artifact with findings, blockers, screenshots by path, and the next CLI action.
+
+Human-in-the-loop boundary:
+
+- Codex may navigate, read screens, click non-destructive controls, and explain state.
+- The user handles credentials, MFA, tenant consent, sends, deletes, license/admin changes, and policy publishing.
+- Return to CLI for code changes, tests, commits, and push.

--- a/skills/setup-wizard/SKILL.md
+++ b/skills/setup-wizard/SKILL.md
@@ -159,6 +159,7 @@ Recommend Codex-specific follow-ups where appropriate:
 - hooks already present or missing
 - config.toml adjustments
 - repo-local docs that should be added
+- Codex Desktop handoff for browser, desktop-app, admin-portal, screenshot, or auth-heavy setup that CLI cannot see. Recommend `codex app .` from the repo root, note that Codex Desktop is available on macOS and Windows, and define the computer-use auth boundary: the user handles credentials, MFA, tenant consent, sends, deletes, license/admin changes, and policy publishing.
 
 When a model profile is selected, ensure the repo-local `.codex/config.toml` matches it. Preserve existing custom config keys and only patch the wizard-owned top-level `model`, `model_reasoning_effort`, `review_model`, and `[features].codex_hooks` settings. Explain that `mixed` is wizard policy, not a native Codex mode, and that project config only loads after the repo is trusted.
 

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -467,6 +467,22 @@ test_feedback_skill_has_privacy_prompt_and_dedupe() {
     fi
 }
 
+test_setup_docs_include_codex_desktop_handoff() {
+    local skill="$REPO_DIR/skills/setup-wizard/SKILL.md"
+    local loop="$REPO_DIR/SDLC-LOOP.md"
+
+    if grep -q 'Codex Desktop handoff' "$loop" \
+        && grep -q 'macOS and Windows' "$loop" \
+        && grep -q 'codex app .' "$loop" \
+        && grep -q 'credentials, MFA, tenant consent' "$loop" \
+        && grep -q 'Codex Desktop handoff' "$skill" \
+        && grep -q 'computer-use' "$skill"; then
+        pass "setup docs include Codex Desktop handoff guidance"
+    else
+        fail "setup docs are missing Codex Desktop handoff guidance"
+    fi
+}
+
 test_sdlc_skill_has_docsync_learning_and_merge_guard() {
     local skill="$REPO_DIR/skills/sdlc/SKILL.md"
 
@@ -789,6 +805,7 @@ test_setup_skill_has_confidence_setup_contract
 test_update_skill_has_idempotent_update_contract
 test_setup_and_update_skills_stop_before_product_remediation
 test_feedback_skill_has_privacy_prompt_and_dedupe
+test_setup_docs_include_codex_desktop_handoff
 test_sdlc_skill_has_docsync_learning_and_merge_guard
 test_repo_defaults_to_xhigh_reasoning
 test_package_has_npm_release_surface


### PR DESCRIPTION
Adds Codex Desktop/computer-use handoff guidance for setup flows that cross browser, desktop app, admin portal, screenshot, or auth UI boundaries. Documents macOS and Windows support, the \codex app .\ entrypoint, repo-local evidence handoff, and the human-owned credentials/MFA/tenant consent boundary.\n\nVerification:\n- bash tests/test-adapter.sh\n- bash tests/test-setup.sh\n- bash tests/test-update.sh