### PR TITLE
docs(setup): add AI Setup Lanes (Premium + Saver)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,10 @@
 2. Run full test suite - ALL tests must pass
 3. Only then: commit and push
 
+## AI Setup Lanes
+
+This repo recommends two setup lanes for AI coding — Setup A (Codex Premium) and Setup B (Codex Saver). Both end at Claude Opus 4.6 max as the cross-model reviewer (different lab, different blind spots); only the planner/driver effort levels differ. See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list (when to use which, credit-spend warning, override policy).
+
 ## Rules
 - Delete legacy code - no backwards compatibility hacks
 - Less is more - don't add what wasn't asked for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 
 ## AI Setup Lanes
 
-This repo recommends two setup lanes for AI coding — Setup A (Codex Premium) and Setup B (Codex Saver). Both end at Claude Opus 4.6 max as the cross-model reviewer (different lab, different blind spots); only the planner/driver effort levels differ. See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list (when to use which, credit-spend warning, override policy).
+This repo recommends two setup lanes — Setup A (Codex Premium: GPT-5.5 xhigh all three roles) and Setup B (Codex Saver: GPT-5.5 xhigh planner+reviewer, GPT-5.4 mini xhigh driver from a different billing bucket). See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list (when to use which, credit-spend warning, override policy).
 
 ## Rules
 - Delete legacy code - no backwards compatibility hacks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 
 ## AI Setup Lanes
 
-This repo recommends two setup lanes — Setup A (Codex Premium: GPT-5.5 xhigh all three roles) and Setup B (Codex Saver: GPT-5.5 xhigh planner+reviewer, GPT-5.4 mini xhigh driver from a different billing bucket). See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list (when to use which, credit-spend warning, override policy).
+This repo recommends two setup lanes — Setup A (Codex Premium: GPT-5.5 xhigh all three roles) and Setup B (Codex Saver: GPT-5.5 xhigh planner+reviewer, GPT-5.3 Codex Spark max driver from a different billing bucket, fallback to GPT-5.4 mini xhigh). See [`AI_SETUP_LANES.md`](AI_SETUP_LANES.md) for the full pick list.
 
 ## Rules
 - Delete legacy code - no backwards compatibility hacks

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -20,7 +20,7 @@ Quality-first lane. GPT-5.5 xhigh all the way through — planning, implementati
 |------|-------|-------|
 | **Planner** | Codex (GPT-5.5) xhigh | |
 | **Driver** | GPT-5.3 Codex Spark (max reasoning) | Primary — different billing bucket (preview) |
-| **Driver fallback** | GPT-5.4 mini xhigh | If Spark unavailable — also a different bucket |
+| **Driver fallback** | GPT-5.4 mini xhigh | If Spark unavailable — same billing pool as GPT-5.5 but cheaper per token |
 | **Reviewer** | Codex (GPT-5.5) xhigh | |
 
 Cost-efficient lane. Keeps GPT-5.5 xhigh as both the planning brain and the final reviewer — where reasoning and judgment matter most. Moves the driver to **GPT-5.3 Codex Spark** (max reasoning), which draws from a separate billing bucket because it's currently a preview model. If Spark isn't available, fall back to **GPT-5.4 mini xhigh** (also a different bucket). The cheaper driver handles routine coding while the flagship reviewer catches what it missed.
@@ -60,7 +60,7 @@ Setup B is sufficient for routine work where the mini driver can ship with a str
 Setup A bills everything against your OpenAI account at GPT-5.5 rates. Setup B's driver draws from a **different billing bucket** than GPT-5.5 — that's the cost-saving mechanism:
 
 - **GPT-5.3 Codex Spark** (primary driver): separate bucket because it's a preview model. Max reasoning keeps quality high while the billing stays off the main GPT-5.5 pool.
-- **GPT-5.4 mini xhigh** (fallback driver): also a different bucket from GPT-5.5.
+- **GPT-5.4 mini xhigh** (fallback driver): same billing pool as GPT-5.5 but cheaper per token.
 
 The planner and reviewer in Setup B still use GPT-5.5, so the savings come specifically from the driver leg being routed to a cheaper billing pool.
 

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -16,13 +16,14 @@ Quality-first lane. GPT-5.5 xhigh all the way through — planning, implementati
 
 ## Setup B — Codex Saver
 
-| Role | Model |
-|------|-------|
-| **Planner** | Codex (GPT-5.5) xhigh |
-| **Driver** | GPT-5.4 mini xhigh |
-| **Reviewer** | Codex (GPT-5.5) xhigh |
+| Role | Model | Notes |
+|------|-------|-------|
+| **Planner** | Codex (GPT-5.5) xhigh | |
+| **Driver** | GPT-5.3 Codex Spark (max reasoning) | Primary — different billing bucket (preview) |
+| **Driver fallback** | GPT-5.4 mini xhigh | If Spark unavailable — also a different bucket |
+| **Reviewer** | Codex (GPT-5.5) xhigh | |
 
-Cost-efficient lane. Keeps GPT-5.5 xhigh as both the planning brain and the final reviewer — where reasoning and judgment matter most. Moves the driver (the implementation grunt work) to GPT-5.4 mini xhigh, which draws from a different billing bucket. The cheaper driver handles routine coding while the flagship reviewer catches what it missed.
+Cost-efficient lane. Keeps GPT-5.5 xhigh as both the planning brain and the final reviewer — where reasoning and judgment matter most. Moves the driver to **GPT-5.3 Codex Spark** (max reasoning), which draws from a separate billing bucket because it's currently a preview model. If Spark isn't available, fall back to **GPT-5.4 mini xhigh** (also a different bucket). The cheaper driver handles routine coding while the flagship reviewer catches what it missed.
 
 ## When to Use Setup A
 
@@ -56,7 +57,12 @@ Setup B is sufficient for routine work where the mini driver can ship with a str
 
 ## Credit-Spend Warning
 
-Setup A bills everything against your OpenAI account at GPT-5.5 rates. Setup B's driver (GPT-5.4 mini) draws from a **different billing bucket** than GPT-5.5 — that's the cost-saving mechanism. The planner and reviewer in Setup B still use GPT-5.5, so the savings come specifically from the driver leg.
+Setup A bills everything against your OpenAI account at GPT-5.5 rates. Setup B's driver draws from a **different billing bucket** than GPT-5.5 — that's the cost-saving mechanism:
+
+- **GPT-5.3 Codex Spark** (primary driver): separate bucket because it's a preview model. Max reasoning keeps quality high while the billing stays off the main GPT-5.5 pool.
+- **GPT-5.4 mini xhigh** (fallback driver): also a different bucket from GPT-5.5.
+
+The planner and reviewer in Setup B still use GPT-5.5, so the savings come specifically from the driver leg being routed to a cheaper billing pool.
 
 ## Maintainer Override
 

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -10,19 +10,19 @@ This is **guidance, not a hard rule**. Maintainer override is always allowed.
 |------|-------|
 | **Planner** | Codex (GPT-5.5) xhigh |
 | **Driver** | Codex (GPT-5.5) xhigh |
-| **Reviewer** | Claude Code (Opus 4.6) max |
+| **Reviewer** | Codex (GPT-5.5) xhigh |
 
-Quality-first lane. GPT-5.5 xhigh drives both the planning brain and the implementation hands; Claude Opus 4.6 max is the cross-model final gate — different lab, different training, different blind spots.
+Quality-first lane. GPT-5.5 xhigh all the way through — planning, implementation, and review all stay at the flagship level. No model switching, no billing-pool surprises. One model, one effort level, maximum quality.
 
 ## Setup B — Codex Saver
 
 | Role | Model |
 |------|-------|
 | **Planner** | Codex (GPT-5.5) xhigh |
-| **Driver** | Codex (GPT-5.5) standard |
-| **Reviewer** | Claude Code (Opus 4.6) max |
+| **Driver** | GPT-5.4 mini xhigh |
+| **Reviewer** | Codex (GPT-5.5) xhigh |
 
-Cost-efficient lane. Keeps GPT-5.5 xhigh as the planning brain — where reasoning matters most — but drops driver effort to standard for routine work. Claude Opus 4.6 max still the final reviewer.
+Cost-efficient lane. Keeps GPT-5.5 xhigh as both the planning brain and the final reviewer — where reasoning and judgment matter most. Moves the driver (the implementation grunt work) to GPT-5.4 mini xhigh, which draws from a different billing bucket. The cheaper driver handles routine coding while the flagship reviewer catches what it missed.
 
 ## When to Use Setup A
 
@@ -40,7 +40,7 @@ Reach for Premium when the change can damage a consumer repo or has high blast r
 
 ## When to Use Setup B
 
-Setup B is sufficient for routine work:
+Setup B is sufficient for routine work where the mini driver can ship with a strong reviewer:
 
 - Routine implementation
 - Documentation
@@ -52,30 +52,11 @@ Setup B is sufficient for routine work:
 
 ## Final Review Policy
 
-**Both lanes end at Claude Opus 4.6 max as the cross-model reviewer.** Codex can't grade its own homework — the reviewer always belongs to a different lab with different blind spots.
-
-**How to run the Claude reviewer from a Codex session:**
-
-```bash
-claude -p \
-  "Read .reviews/handoff.json and review per the checklist. Output findings + CERTIFIED or NOT CERTIFIED." \
-  --model claude-opus-4-6[1m] \
-  --output-format text \
-  > .reviews/latest-review.md
-```
-
-Append `< /dev/null` if running from a non-interactive parent. Use `--model claude-opus-4-6[1m]` explicitly — this pins the reviewer to the wizard's recommended flagship, not whatever alias resolves to. If `claude` CLI is not installed, use `npx @anthropic-ai/claude-code` or the API directly.
+**Both lanes end at GPT-5.5 xhigh as the reviewer.** The review step catches what the driver missed — in Setup A that's self-review at flagship; in Setup B the flagship reviewer catches what the mini driver missed.
 
 ## Credit-Spend Warning
 
-Both lanes use GPT-5.5 for the planner + driver — billed against your OpenAI account. The reviewer (Claude Opus 4.6 max) bills against your Anthropic Max subscription for interactive use, or against the Anthropic credit pool for headless `claude -p` use (post-June-15-2026 billing split).
-
-If you're running the reviewer via `claude -p` (headless), that draws from your Anthropic credits:
-- Max 5x: $100/mo
-- Max 20x: $200/mo
-- No rollover
-
-For interactive Claude Code reviews (you open a separate Claude Code session to review), it stays on your Max subscription — no credit drawdown.
+Setup A bills everything against your OpenAI account at GPT-5.5 rates. Setup B's driver (GPT-5.4 mini) draws from a **different billing bucket** than GPT-5.5 — that's the cost-saving mechanism. The planner and reviewer in Setup B still use GPT-5.5, so the savings come specifically from the driver leg.
 
 ## Maintainer Override
 
@@ -86,4 +67,4 @@ The wizard does not enforce setup lane selection — it documents the recommende
 ## See Also
 
 - [`AGENTS.md`](AGENTS.md) — SDLC enforcement rules for this repo
-- [claude-sdlc-wizard `AI_SETUP_LANES.md`](https://github.com/BaseInfinity/claude-sdlc-wizard/blob/main/AI_SETUP_LANES.md) — Sibling lanes doc for Claude Code environments (Setup A/B use Claude Opus 4.6 max as primary coder, GPT-5.5 xhigh as reviewer — the inverse of this doc)
+- [claude-sdlc-wizard `AI_SETUP_LANES.md`](https://github.com/BaseInfinity/claude-sdlc-wizard/blob/main/AI_SETUP_LANES.md) — Sibling lanes doc for Claude Code environments (uses Opus 4.6 max as primary coder + GPT-5.5 xhigh as cross-model reviewer — the Claude-side equivalent)

--- a/AI_SETUP_LANES.md
+++ b/AI_SETUP_LANES.md
@@ -1,0 +1,89 @@
+# AI Setup Lanes
+
+Two recommended AI coding setups for this repo. Each is a complete triad: **planner → driver → reviewer**.
+
+This is **guidance, not a hard rule**. Maintainer override is always allowed.
+
+## Setup A — Codex Premium
+
+| Role | Model |
+|------|-------|
+| **Planner** | Codex (GPT-5.5) xhigh |
+| **Driver** | Codex (GPT-5.5) xhigh |
+| **Reviewer** | Claude Code (Opus 4.6) max |
+
+Quality-first lane. GPT-5.5 xhigh drives both the planning brain and the implementation hands; Claude Opus 4.6 max is the cross-model final gate — different lab, different training, different blind spots.
+
+## Setup B — Codex Saver
+
+| Role | Model |
+|------|-------|
+| **Planner** | Codex (GPT-5.5) xhigh |
+| **Driver** | Codex (GPT-5.5) standard |
+| **Reviewer** | Claude Code (Opus 4.6) max |
+
+Cost-efficient lane. Keeps GPT-5.5 xhigh as the planning brain — where reasoning matters most — but drops driver effort to standard for routine work. Claude Opus 4.6 max still the final reviewer.
+
+## When to Use Setup A
+
+Reach for Premium when the change can damage a consumer repo or has high blast radius:
+
+- Architecture or methodology changes
+- Tagged release prep
+- Installer behavior (`install.sh`, `setup.sh`, `bin/`)
+- Destructive file operations
+- Package publishing
+- Generated repo modifications (template changes)
+- CI / release automation
+- Security-sensitive behavior
+- Anything that could damage a consumer repo
+
+## When to Use Setup B
+
+Setup B is sufficient for routine work:
+
+- Routine implementation
+- Documentation
+- Examples
+- Tests
+- Normal script changes (non-installer)
+- Low-risk methodology edits
+- Mechanical refactors
+
+## Final Review Policy
+
+**Both lanes end at Claude Opus 4.6 max as the cross-model reviewer.** Codex can't grade its own homework — the reviewer always belongs to a different lab with different blind spots.
+
+**How to run the Claude reviewer from a Codex session:**
+
+```bash
+claude -p \
+  "Read .reviews/handoff.json and review per the checklist. Output findings + CERTIFIED or NOT CERTIFIED." \
+  --model claude-opus-4-6[1m] \
+  --output-format text \
+  > .reviews/latest-review.md
+```
+
+Append `< /dev/null` if running from a non-interactive parent. Use `--model claude-opus-4-6[1m]` explicitly — this pins the reviewer to the wizard's recommended flagship, not whatever alias resolves to. If `claude` CLI is not installed, use `npx @anthropic-ai/claude-code` or the API directly.
+
+## Credit-Spend Warning
+
+Both lanes use GPT-5.5 for the planner + driver — billed against your OpenAI account. The reviewer (Claude Opus 4.6 max) bills against your Anthropic Max subscription for interactive use, or against the Anthropic credit pool for headless `claude -p` use (post-June-15-2026 billing split).
+
+If you're running the reviewer via `claude -p` (headless), that draws from your Anthropic credits:
+- Max 5x: $100/mo
+- Max 20x: $200/mo
+- No rollover
+
+For interactive Claude Code reviews (you open a separate Claude Code session to review), it stays on your Max subscription — no credit drawdown.
+
+## Maintainer Override
+
+**Override at any time.** A blanket setup choice doesn't replace judgment per change. If you're touching CI but the change is a one-line typo, Setup B is fine. If you're touching docs but the section is the installer's safety-critical path, Setup A is the call.
+
+The wizard does not enforce setup lane selection — it documents the recommended default per change shape. Whatever ships is your call.
+
+## See Also
+
+- [`AGENTS.md`](AGENTS.md) — SDLC enforcement rules for this repo
+- [claude-sdlc-wizard `AI_SETUP_LANES.md`](https://github.com/BaseInfinity/claude-sdlc-wizard/blob/main/AI_SETUP_LANES.md) — Sibling lanes doc for Claude Code environments (Setup A/B use Claude Opus 4.6 max as primary coder, GPT-5.5 xhigh as reviewer — the inverse of this doc)


### PR DESCRIPTION
## Summary

Adapts the AI Setup Lanes pattern from [claude-sdlc-wizard v1.79.0 (#378)](https://github.com/BaseInfinity/claude-sdlc-wizard/blob/main/AI_SETUP_LANES.md) for the Codex environment.

**The reviewer flips:** in Claude's world, GPT-5.5 is the cross-model reviewer. In Codex's world, **Claude Opus 4.6 max** is the cross-model reviewer. Same principle (different lab, different blind spots), opposite direction.

## The two lanes

**Setup A — Codex Premium**
| Role | Model |
|------|-------|
| Planner | Codex GPT-5.5 xhigh |
| Driver | Codex GPT-5.5 xhigh |
| Reviewer | Claude Code Opus 4.6 max |

**Setup B — Codex Saver**
| Role | Model |
|------|-------|
| Planner | Codex GPT-5.5 xhigh |
| Driver | Codex GPT-5.5 standard |
| Reviewer | Claude Code Opus 4.6 max |

## What ships

- `AI_SETUP_LANES.md` — new file with all required sections (Purpose, Setup A, Setup B, When to use A/B, Final review policy with `claude -p` invocation example, Credit-spend warning noting June 15 billing split, Maintainer override note, cross-link to Claude sibling doc)
- `AGENTS.md` — adds "AI Setup Lanes" section linking to the new doc

Pure docs — no version bump, no source/package changes.

## Test plan

- [ ] CI passes
- [ ] Run `claude -p` reviewer command from a Codex session against a test handoff.json to verify the cross-model review path works end-to-end