### PR TITLE
fix(plugin): distinguish picker intents

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -19,7 +19,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Codex SDLC Wizard",
-    "shortDescription": "Install Codex SDLC guardrails",
+    "shortDescription": "Explore Codex SDLC workflows",
     "longDescription": "Install, configure, update, and repair repository-scoped SDLC skills, hooks, and guidance for Codex.",
     "developerName": "BaseInfinity",
     "category": "Developer Tools",
@@ -27,7 +27,7 @@
       "Write"
     ],
     "websiteURL": "https://github.com/BaseInfinity/codex-sdlc-wizard",
-    "defaultPrompt": "Install or update Codex SDLC enforcement in this repository.",
+    "defaultPrompt": "Show me the Codex SDLC Wizard workflows available for this repository and help me choose the right one.",
     "brandColor": "#10A37F",
     "composerIcon": "./assets/composer-icon.svg",
     "logo": "./assets/logo.svg"

--- a/skills/codex-sdlc-wizard/agents/openai.yaml
+++ b/skills/codex-sdlc-wizard/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Codex SDLC Wizard"
-  short_description: "Install Codex SDLC guardrails"
+  display_name: "Install SDLC Guardrails"
+  short_description: "Set up or repair repo SDLC"
   default_prompt: "Use $codex-sdlc-wizard to install or update Codex SDLC enforcement in this repository."

--- a/tests/test-skill.sh
+++ b/tests/test-skill.sh
@@ -8,6 +8,7 @@ REPO_DIR="$SCRIPT_DIR/.."
 README="$REPO_DIR/README.md"
 SKILL_MD="$REPO_DIR/skills/codex-sdlc-wizard/SKILL.md"
 OPENAI_YAML="$REPO_DIR/skills/codex-sdlc-wizard/agents/openai.yaml"
+PLUGIN_MANIFEST="$REPO_DIR/.codex-plugin/plugin.json"
 REPO_SDLC_SKILL="$REPO_DIR/.agents/skills/sdlc/SKILL.md"
 REPO_ADLC_SKILL="$REPO_DIR/.agents/skills/adlc/SKILL.md"
 GLOBAL_SKILL_SOURCES="$REPO_DIR/skill-sources"
@@ -143,6 +144,39 @@ test_agents_openai_yaml_exists() {
         pass "agents/openai.yaml exists with Codex skill metadata"
     else
         fail "agents/openai.yaml is missing or incomplete"
+    fi
+}
+
+test_plugin_and_installer_skill_have_distinct_picker_intents() {
+    local plugin_default_prompt
+    local plugin_display_name
+    local plugin_short_description
+    local skill_default_prompt
+    local skill_display_name
+    local skill_short_description
+    local valid=true
+
+    plugin_default_prompt=$(node -e 'process.stdout.write(require(process.argv[1]).interface.defaultPrompt)' "$PLUGIN_MANIFEST")
+    plugin_display_name=$(node -e 'process.stdout.write(require(process.argv[1]).interface.displayName)' "$PLUGIN_MANIFEST")
+    plugin_short_description=$(node -e 'process.stdout.write(require(process.argv[1]).interface.shortDescription)' "$PLUGIN_MANIFEST")
+    skill_default_prompt=$(sed -n 's/^  default_prompt: "\(.*\)"$/\1/p' "$OPENAI_YAML")
+    skill_display_name=$(sed -n 's/^  display_name: "\(.*\)"$/\1/p' "$OPENAI_YAML")
+    skill_short_description=$(sed -n 's/^  short_description: "\(.*\)"$/\1/p' "$OPENAI_YAML")
+
+    [ "$plugin_display_name" = "Codex SDLC Wizard" ] || valid=false
+    [ "$plugin_short_description" = "Explore Codex SDLC workflows" ] || valid=false
+    [ "$plugin_default_prompt" = "Show me the Codex SDLC Wizard workflows available for this repository and help me choose the right one." ] || valid=false
+    [ "$skill_display_name" = "Install SDLC Guardrails" ] || valid=false
+    [ "$skill_short_description" = "Set up or repair repo SDLC" ] || valid=false
+    [ "$skill_default_prompt" = "Use \$codex-sdlc-wizard to install or update Codex SDLC enforcement in this repository." ] || valid=false
+    [ "$plugin_display_name" != "$skill_display_name" ] || valid=false
+    [ "$plugin_short_description" != "$skill_short_description" ] || valid=false
+    [ "$plugin_default_prompt" != "$skill_default_prompt" ] || valid=false
+
+    if [ "$valid" = "true" ]; then
+        pass "Plugin and bundled installer skill have distinct picker intents"
+    else
+        fail "Plugin and bundled installer skill are ambiguous in the picker"
     fi
 }
 
@@ -415,6 +449,7 @@ test_plugin_skill_resolves_bundled_scripts_from_plugin_root
 test_plugin_skill_handles_legacy_standalone_install
 test_plugin_skill_documents_surface_specific_installation
 test_agents_openai_yaml_exists
+test_plugin_and_installer_skill_have_distinct_picker_intents
 test_readme_documents_dual_distribution
 test_readme_recommends_current_codex_startup
 test_skill_recommends_current_codex_after_install


### PR DESCRIPTION
## What changed

- Keep the plugin row as `Codex SDLC Wizard`, but make it an exploratory workflow entry: `Explore Codex SDLC workflows`.
- Rename the bundled installer skill row to `Install SDLC Guardrails` with the explicit setup/repair intent.
- Add a regression test that locks the plugin and skill labels, descriptions, and prompts as distinct intents.

## Why

Issue #69 traced the picker rows to four sources. One was the intended repo-local `$sdlc` lifecycle skill, one was a stale pre-plugin standalone installer, and two were the legitimate plugin and bundled-skill projections. After the stale standalone bundle is retired, Codex still intentionally renders the plugin and its bundled skill separately. They previously had the same install/update presentation, so users could not tell which row to choose.

This patch makes the plugin row an overview/router and leaves one explicit install/repair action on the bundled skill.

## User impact

A fresh picker now presents three clear choices:

1. `sdlc (codex-sdlc-wizard)` — run the repo lifecycle workflow.
2. `Codex SDLC Wizard` — explore the plugin's available workflows.
3. `Install SDLC Guardrails` — install, update, or repair repo enforcement.

## Validation

- TDD regression observed failing before the metadata patch and passing afterward.
- Plugin Creator validation passed.
- Skill Creator validation passed.
- Full 11-group proof suite passed, including packaging, npm tarball, adapter, setup, and update/migration coverage.
- Native `codex review --uncommitted` with `gpt-5.6-sol` at `xhigh` returned no actionable findings.
- Reinstalled local personal plugin `0.7.34+codex.20260730062321` and verified the three distinct rows in a fresh Codex CLI v0.145.0 picker.
- Token-consuming live Codex E2E remains opt-in and was skipped by design.
- Merged ChatGPT/Codex desktop picker acceptance remains open because the Computer Use native pipe was unavailable in this session.

Progresses #69.
