### PR TITLE
Release 0.7.35: harden Codex Desktop installation

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-sdlc-wizard",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "description": "Install and maintain Codex SDLC enforcement in local repositories.",
   "author": {
     "name": "BaseInfinity",
@@ -19,7 +19,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Codex SDLC Wizard",
-    "shortDescription": "Install Codex SDLC guardrails",
+    "shortDescription": "Explore Codex SDLC workflows",
     "longDescription": "Install, configure, update, and repair repository-scoped SDLC skills, hooks, and guidance for Codex.",
     "developerName": "BaseInfinity",
     "category": "Developer Tools",
@@ -27,7 +27,7 @@
       "Write"
     ],
     "websiteURL": "https://github.com/BaseInfinity/codex-sdlc-wizard",
-    "defaultPrompt": "Install or update Codex SDLC enforcement in this repository.",
+    "defaultPrompt": "Show me the Codex SDLC Wizard workflows available for this repository and help me choose the right one.",
     "brandColor": "#10A37F",
     "composerIcon": "./assets/composer-icon.svg",
     "logo": "./assets/logo.svg"

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ After either path changes skills, hooks, hook config, or helper scripts, restart
 Useful follow-ups after install:
 
 ```bash
-npx codex-sdlc-wizard@0.7.34 check
-npx codex-sdlc-wizard@0.7.34 update
+npx codex-sdlc-wizard@0.7.35 check
+npx codex-sdlc-wizard@0.7.35 update
 ```
 
 If you want pinned release examples instead of `@latest`, see [Releases](#releases).
@@ -231,10 +231,10 @@ How to choose:
 
 ```bash
 # recommended interactive bootstrap path
-npx codex-sdlc-wizard@0.7.34 --model-profile maximum
+npx codex-sdlc-wizard@0.7.35 --model-profile maximum
 
 # experimental efficiency trial when you explicitly choose it
-npx codex-sdlc-wizard@0.7.34 --model-profile mixed
+npx codex-sdlc-wizard@0.7.35 --model-profile mixed
 
 # floating latest release with the same bootstrap recommendation
 npx codex-sdlc-wizard@latest --model-profile maximum
@@ -375,7 +375,7 @@ If you are consuming this repo in a real project, prefer a tagged release over `
 
 ```bash
 # npm / npx pinned to the current release
-npx codex-sdlc-wizard@0.7.34
+npx codex-sdlc-wizard@0.7.35
 
 # npm / npx floating on the newest published release
 npx codex-sdlc-wizard@latest
@@ -385,7 +385,7 @@ npx codex-sdlc-wizard@latest
 # so $codex-sdlc-wizard is available inside Codex
 
 # git-based install
-git clone --branch v0.7.34 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
+git clone --branch v0.7.35 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
 ```
 
 ### Maintainer Release Flow

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- `codex-sdlc-wizard@0.7.34` and `v0.7.34` are the current release target for the first skills-only plugin distribution
+- `codex-sdlc-wizard@0.7.34` and `v0.7.34` are the current published release; `0.7.35` is the Desktop-readiness release candidate
 - npm trusted publishing is configured and the GitHub release workflow is now proven for real OIDC publish
 - the repo now ships a skills-only Codex plugin (`.codex-plugin/plugin.json` pointing to `skills/`), one installer skill at `skills/codex-sdlc-wizard/SKILL.md`, and the installer/setup adapter (`install.sh`, `setup.sh`)
 - the plugin declares no MCP servers, apps, or plugin-level hooks; repo-scoped enforcement remains the responsibility of the adaptive installer
@@ -58,28 +58,27 @@
 
 ## Next Release Cycle
 
-### 0.7.34
+### 0.7.35
 
-Purpose: ship and validate the skills-only plugin package across the supported OpenAI surfaces, then continue pilot rollout while keeping runtime patches tied to proven reusable wizard bugs.
+Purpose: harden plugin-driven installation before final supported-surface validation and public directory submission.
 
 Scope:
-- package `.codex-plugin/plugin.json` and `skills/codex-sdlc-wizard/SKILL.md` in npm without introducing duplicate skill discovery
-- validate install/discovery and one real repo mutation from ChatGPT Work where project access permits it, the Codex desktop app, and Codex CLI
-- keep the existing npx path as the deterministic repo-mutation engine and preserve `0.7.33` runtime behavior as the Sol-high consumer baseline
-- keep programmatic `/goal` automation unassumed unless Codex exposes a stable CLI/API path for it
-- cut another stabilization patch only if real consumption surfaces another reusable wizard bug
-- keep separate model-profile measurement running, but do not let it block pilot rollout work
+- preserve unrelated host hooks while replacing only wizard-owned hook entries during install and repair
+- keep successful artifact installation successful when the optional nested Codex handoff cannot start or exits with an ordinary failure
+- refresh manifest hashes only for installer-touched artifacts and preserve untouched customizations
+- distinguish plugin exploration, install/repair, and repo-local lifecycle intents in the picker
+- validate the exact release candidate through Claude-driven black-box Codex Desktop and ChatGPT Work E2E before publishing
 
 ## Tracker Cleanup
 
-The stabilization tracker is clear after `0.7.33`: #61 is resolved by preventing a repo-root skill install from recursively exposing bundled helper definitions as duplicate skills. There is no active packaging or stabilization fix; remaining open docs/research issues stay outside the stabilization lane.
+The `0.7.35` stabilization set is intentionally limited to #55, #56, and the picker-intent fix from #69/PR #70. Issue #66 owns the final supported-surface E2E and public directory submission; remaining docs/research issues stay outside this release lane.
 
 - open a new issue only when pilot consumption exposes another proven reusable wizard bug
-- avoid speculative backlog churn while `0.7.33` is being consumed on real repos
+- avoid speculative backlog churn while `0.7.35` is being validated on supported Codex surfaces
 
 ## Remaining Backlog
 
-After `0.7.34`, the main backlog is:
+After `0.7.35`, the main backlog is:
 
 - complete supported-surface plugin validation and submit the public directory listing
 - any new reusable wizard fixes discovered during the pilot set
@@ -90,7 +89,7 @@ After `0.7.34`, the main backlog is:
 
 Official Codex docs make plugins the installable distribution unit for reusable skills, apps, MCP servers, and presentation assets. The implementation outcome for this repo is a skills-only plugin: `.codex-plugin/plugin.json` points to the conventional `skills/` directory and its single installer skill, while npx remains the repo-mutation engine.
 
-- Package the manifest in `codex-sdlc-wizard@0.7.34` so the same artifact carries the plugin skill and the existing CLI/installer.
+- Package the manifest in `codex-sdlc-wizard@0.7.35` so the same artifact carries the plugin skill and the existing CLI/installer.
 - Validate discovery in ChatGPT Work, the Codex desktop app, and Codex CLI. Ordinary Chat remains outside the supported plugin surfaces.
 - Keep MCP servers, apps, and plugin-level hooks out until a proven product need exists; the installer continues to write repo-local hooks and config.
 - The official submission portal is live; the public listing is pending supported-surface validation and submission.

--- a/bin/codex-sdlc-wizard.js
+++ b/bin/codex-sdlc-wizard.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 const readline = require("node:readline/promises");
 
 const scriptDir = path.resolve(__dirname, "..");
+const packageVersion = require(path.join(scriptDir, "package.json")).version;
 const rawArgs = process.argv.slice(2);
 const codexCommand = process.env.CODEX_SDLC_CODEX_BIN || "codex";
 const minimumGpt56CodexVersion = [0, 144, 0];
@@ -234,6 +235,22 @@ function printHandoffRecovery(reason) {
     "Retry from this repo with: npx codex-sdlc-wizard@latest",
     "If Codex printed a session id before stopping, resume with: codex resume -m gpt-5.6-sol -c 'model_reasoning_effort=\"high\"' <session-id>",
     `For full-trust/yolo-style resume, use: codex resume ${fullTrustFlag} -m gpt-5.6-sol -c 'model_reasoning_effort=\"high\"' <session-id>`,
+    ""
+  ].join("\n"));
+}
+
+function printOptionalHandoffWarning(reason, modelProfile, options) {
+  const recoveryArgs = ["setup", "--yes", "--model-profile", modelProfile];
+  if (options.generateGoals) {
+    recoveryArgs.push("--goals");
+  }
+
+  process.stderr.write([
+    "",
+    "Warning: repository artifacts were installed successfully, but the optional Codex setup handoff failed.",
+    reason,
+    "The completed artifact install is still usable.",
+    `Finish setup without a nested handoff with: npx codex-sdlc-wizard@${packageVersion} ${recoveryArgs.join(" ")}`,
     ""
   ].join("\n"));
 }
@@ -540,11 +557,20 @@ async function handoffToCodex(modelProfile, options) {
   const codexResult = await runCodexHandoff(codexArgs);
 
   if (codexResult.error) {
-    process.stderr.write(`${codexResult.error.message}\n`);
-    process.exit(1);
+    printOptionalHandoffWarning(codexResult.error.message, modelProfile, options);
+    return 0;
   }
 
-  return codexResult.status === null ? 1 : codexResult.status;
+  if (codexResult.timedOut || codexResult.interruptedSignal || codexResult.signal) {
+    return codexResult.status === null ? 1 : codexResult.status;
+  }
+
+  if (codexResult.status !== 0) {
+    printOptionalHandoffWarning(`Codex exited with status ${codexResult.status === null ? 1 : codexResult.status}.`, modelProfile, options);
+    return 0;
+  }
+
+  return 0;
 }
 
 async function main() {

--- a/check.sh
+++ b/check.sh
@@ -25,10 +25,11 @@ for arg in "$@"; do
     esac
 done
 
-node - <<'NODE'
+node - "$SCRIPT_DIR/lib/merge-hooks.cjs" <<'NODE'
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
+const { directoryFoldsCase, validateHooksDocument, wizardCommandPath } = require(process.argv[2]);
 
 const cwd = process.cwd();
 const manifestPath = path.join(cwd, ".codex-sdlc", "manifest.json");
@@ -70,17 +71,34 @@ function hasPlatformHookDrift(relativePath, absolutePath) {
     return false;
   }
 
-  const content = fs.readFileSync(absolutePath, "utf8");
-
-  if (content.includes(".codex/hooks/git-guard.js") || content.includes(".codex/hooks/session-start.js")) {
+  let document;
+  try {
+    const content = fs.readFileSync(absolutePath, "utf8").replace(/^\uFEFF/, "");
+    document = JSON.parse(content);
+    validateHooksDocument(document, relativePath);
+  } catch (_error) {
+    return true;
+  }
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
     return true;
   }
 
-  if (process.platform === "win32") {
-    return content.includes("bash-guard.sh") || content.includes("session-start.sh");
-  }
+  const foldPathCase = directoryFoldsCase(path.dirname(absolutePath));
+  const commands = Object.values(document.hooks || {}).flatMap((entries) =>
+    Array.isArray(entries) ? entries.flatMap((entry) =>
+      Array.isArray(entry?.hooks) ? entry.hooks.map((hook) => hook?.command) : []) : [],
+  );
+  const scriptPaths = commands
+    .map((command) => wizardCommandPath(command, foldPathCase))
+    .filter(Boolean);
 
-  return content.includes("powershell.exe");
+  if (scriptPaths.some((scriptPath) => /\/(?:git-guard|session-start)\.js$/.test(scriptPath))) {
+    return true;
+  }
+  if (process.platform === "win32") {
+    return scriptPaths.some((scriptPath) => /\/(?:bash-guard|session-start)\.sh$/.test(scriptPath));
+  }
+  return scriptPaths.some((scriptPath) => /\/(?:git-guard|session-start)\.ps1$/.test(scriptPath));
 }
 
 function hasManagedHookSurfaceDrift(relativePath, absolutePath) {

--- a/install.ps1
+++ b/install.ps1
@@ -7,6 +7,14 @@ $ErrorActionPreference = "Stop"
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $minimumGpt56CodexVersion = [version]"0.144.0"
+$touchedFiles = [System.Collections.Generic.List[string]]::new()
+
+function Add-TouchedFile {
+    param([string]$Path)
+    if (-not $script:touchedFiles.Contains($Path)) {
+        $script:touchedFiles.Add($Path)
+    }
+}
 
 function Assert-Gpt56CodexVersion {
     $codexExecutable = if ($env:CODEX_SDLC_CODEX_BIN) { $env:CODEX_SDLC_CODEX_BIN } else { "codex" }
@@ -59,6 +67,7 @@ function Install-AgentsBaseline {
     $content = Get-Content -LiteralPath $Source -Raw
     $content = $content.Replace("{{MODEL_PROFILE}}", $Profile).Replace("{{REASONING_BASELINE}}", $reasoningBaseline)
     Set-Content -LiteralPath "AGENTS.md" -Value $content -NoNewline
+    Add-TouchedFile -Path "AGENTS.md"
     Write-Host "Created AGENTS.md"
 }
 
@@ -71,6 +80,7 @@ function Copy-IfMissing {
 
     if (-not (Test-Path -LiteralPath $Destination)) {
         Copy-Item -LiteralPath $Source -Destination $Destination
+        Add-TouchedFile -Path $Destination
         Write-Host "Created $Label"
     } else {
         Write-Host "$Label already exists - skipping (review manually)"
@@ -97,6 +107,7 @@ function Install-RepoSkill {
 
     New-Item -ItemType Directory -Path (Split-Path -Parent $repoSkillTarget) -Force | Out-Null
     Copy-Item -LiteralPath $repoSkillSource -Destination $repoSkillTarget
+    Add-TouchedFile -Path ".agents/skills/$Name/SKILL.md"
     Write-Host "Installed $repoSkillTarget"
 }
 
@@ -390,10 +401,21 @@ function Write-ModelProfile {
     }
 
     $metadata | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath ".codex-sdlc\model-profile.json"
+    Add-TouchedFile -Path ".codex-sdlc/model-profile.json"
     Write-Host "Wrote .codex-sdlc/model-profile.json ($Profile)"
 }
 
 Assert-Gpt56CodexVersion
+
+$hooksPath = ".codex\hooks.json"
+$hooksTemplate = Join-Path $scriptDir ".codex\windows-hooks.json"
+$hooksMergeStatus = (& node (Join-Path $scriptDir "lib\merge-hooks.cjs") --status $hooksPath $hooksTemplate | Out-String).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to inspect .codex/hooks.json"
+}
+if ($hooksMergeStatus -eq "target-broken") {
+    throw ".codex/hooks.json must contain a valid hooks object before baseline installation"
+}
 
 Write-Host "Installing SDLC Wizard for Codex CLI..."
 
@@ -410,23 +432,47 @@ New-Item -ItemType Directory -Path ".codex\hooks" -Force | Out-Null
 
 $configPath = ".codex\config.toml"
 Merge-CodexModelConfig -ConfigPath $configPath -Profile $ModelProfile
+Add-TouchedFile -Path ".codex/config.toml"
 Write-Host "Merged repo-local Codex config for model profile '$ModelProfile'"
 Write-ModelProfile -Profile $ModelProfile
 
-$hooksPath = ".codex\hooks.json"
 if (Test-Path -LiteralPath $hooksPath) {
     $timestamp = Get-Date -Format "yyyyMMddHHmmss"
     Copy-Item -LiteralPath $hooksPath -Destination ".codex\hooks.json.bak.$timestamp"
     Write-Host "Backed up existing hooks.json"
 }
 
-Copy-Item -LiteralPath (Join-Path $scriptDir ".codex\windows-hooks.json") -Destination $hooksPath
+& node (Join-Path $scriptDir "lib\merge-hooks.cjs") $hooksPath $hooksTemplate
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to merge .codex/hooks.json"
+}
 Copy-Item -LiteralPath (Join-Path $scriptDir ".codex\hooks\git-guard.cjs") -Destination ".codex\hooks\git-guard.cjs"
 Copy-Item -LiteralPath (Join-Path $scriptDir ".codex\hooks\session-start.cjs") -Destination ".codex\hooks\session-start.cjs"
 Copy-Item -LiteralPath (Join-Path $scriptDir ".codex\hooks\compact-guard.cjs") -Destination ".codex\hooks\compact-guard.cjs"
 Copy-Item -LiteralPath (Join-Path $scriptDir ".codex\hooks\git-guard.ps1") -Destination ".codex\hooks\git-guard.ps1"
 Copy-Item -LiteralPath (Join-Path $scriptDir ".codex\hooks\session-start.ps1") -Destination ".codex\hooks\session-start.ps1"
 Remove-Item -LiteralPath ".codex\hooks\git-guard.js", ".codex\hooks\session-start.js" -ErrorAction SilentlyContinue
+Add-TouchedFile -Path ".codex/hooks/git-guard.js"
+Add-TouchedFile -Path ".codex/hooks/session-start.js"
+
+foreach ($touchedHook in @(
+    ".codex/hooks/git-guard.cjs",
+    ".codex/hooks/session-start.cjs",
+    ".codex/hooks/compact-guard.cjs",
+    ".codex/hooks/git-guard.ps1",
+    ".codex/hooks/session-start.ps1"
+)) {
+    Add-TouchedFile -Path $touchedHook
+}
+if ($hooksMergeStatus -eq "merge") {
+    Add-TouchedFile -Path ".codex/hooks.json"
+}
+
+$touchedFileArgs = $touchedFiles.ToArray()
+& node (Join-Path $scriptDir "lib\refresh-manifest-hashes.cjs") ".codex-sdlc\manifest.json" @touchedFileArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to refresh .codex-sdlc/manifest.json hashes"
+}
 
 Write-Host "Installed .codex/hooks.json (universal Node hooks)"
 Write-Host "Installed Node and PowerShell hook scripts"

--- a/install.sh
+++ b/install.sh
@@ -86,6 +86,8 @@ for required in \
   ".codex/hooks/compact-guard.cjs" \
   ".codex/hooks/git-guard.ps1" \
   ".codex/hooks/session-start.ps1" \
+  "lib/merge-hooks.cjs" \
+  "lib/refresh-manifest-hashes.cjs" \
   ".agents/skills/sdlc/SKILL.md"; do
   require_bundle_file "$SCRIPT_DIR/$required" "$required"
 done
@@ -94,6 +96,11 @@ CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
 SKILLS_ROOT="$CODEX_HOME_DIR/skills"
 SKILLS_BACKUP_ROOT="$CODEX_HOME_DIR/backups/skills"
 GLOBAL_HELPER_SKILLS=("feedback" "setup-wizard" "update-wizard")
+INSTALL_TOUCHED_FILES=()
+
+mark_install_touched() {
+  INSTALL_TOUCHED_FILES+=("$1")
+}
 
 copy_if_missing() {
   local source="$1"
@@ -101,6 +108,7 @@ copy_if_missing() {
   local label="$3"
   if [ ! -f "$target" ]; then
     cp "$source" "$target"
+    mark_install_touched "$target"
     echo "Created $label"
   else
     echo "$label already exists - skipping (review manually)"
@@ -117,6 +125,7 @@ install_repo_skill() {
     echo "$target already exists - skipping (review manually)"
   else
     cp "$source" "$target"
+    mark_install_touched "$target"
     echo "Installed $target"
   fi
 }
@@ -218,6 +227,7 @@ prune_legacy_global_skill() {
 
 write_model_profile() {
   write_model_profile_metadata ".codex-sdlc/model-profile.json" "$MODEL_PROFILE"
+  mark_install_touched ".codex-sdlc/model-profile.json"
   echo "Wrote .codex-sdlc/model-profile.json ($MODEL_PROFILE)"
 }
 
@@ -236,8 +246,20 @@ install_agents_baseline() {
     -e "s|{{MODEL_PROFILE}}|$MODEL_PROFILE|g" \
     -e "s|{{REASONING_BASELINE}}|$reasoning_baseline|g" \
     "$source" > "$target"
+  mark_install_touched "$target"
   echo "Created AGENTS.md"
 }
+
+if [ "$IS_WINDOWS" = "true" ]; then
+  HOOKS_TEMPLATE="$SCRIPT_DIR/.codex/windows-hooks.json"
+else
+  HOOKS_TEMPLATE="$SCRIPT_DIR/.codex/unix-hooks.json"
+fi
+HOOKS_MERGE_STATUS="$(node "$SCRIPT_DIR/lib/merge-hooks.cjs" --status .codex/hooks.json "$HOOKS_TEMPLATE")"
+if [ "$HOOKS_MERGE_STATUS" = "target-broken" ]; then
+  echo "Error: .codex/hooks.json must contain a valid hooks object before baseline installation" >&2
+  exit 1
+fi
 
 echo "Installing SDLC Wizard for Codex CLI..."
 
@@ -256,6 +278,7 @@ prune_legacy_global_skill "codex-sdlc" "sdlc"
 mkdir -p .codex/hooks
 
 merge_codex_config_profile ".codex/config.toml" "$MODEL_PROFILE"
+mark_install_touched ".codex/config.toml"
 echo "Merged repo-local Codex config for model profile '$MODEL_PROFILE'"
 
 if [ -f ".codex/hooks.json" ]; then
@@ -267,25 +290,44 @@ cp "$SCRIPT_DIR/.codex/hooks/"*.sh .codex/hooks/
 chmod +x .codex/hooks/*.sh
 cp "$SCRIPT_DIR/.codex/hooks/"*.cjs .codex/hooks/
 rm -f .codex/hooks/git-guard.js .codex/hooks/session-start.js
+mark_install_touched ".codex/hooks/git-guard.js"
+mark_install_touched ".codex/hooks/session-start.js"
 
 if [ "$IS_WINDOWS" = "true" ]; then
-  cp "$SCRIPT_DIR/.codex/windows-hooks.json" .codex/hooks.json
+  node "$SCRIPT_DIR/lib/merge-hooks.cjs" .codex/hooks.json "$HOOKS_TEMPLATE"
   cp "$SCRIPT_DIR/.codex/hooks/git-guard.ps1" .codex/hooks/
   cp "$SCRIPT_DIR/.codex/hooks/session-start.ps1" .codex/hooks/
   copy_if_missing "$SCRIPT_DIR/start-sdlc.ps1" "start-sdlc.ps1" "start-sdlc.ps1"
   echo "Installed .codex/hooks.json (universal Node hooks)"
   echo "Installed Node and PowerShell hook scripts"
 else
-  cp "$SCRIPT_DIR/.codex/unix-hooks.json" .codex/hooks.json
+  node "$SCRIPT_DIR/lib/merge-hooks.cjs" .codex/hooks.json "$HOOKS_TEMPLATE"
   copy_if_missing "$SCRIPT_DIR/start-sdlc.sh" "start-sdlc.sh" "start-sdlc.sh"
   chmod +x start-sdlc.sh
   echo "Installed .codex/hooks.json (universal Node hooks)"
+fi
+if [ "$HOOKS_MERGE_STATUS" = "merge" ]; then
+  mark_install_touched ".codex/hooks.json"
+fi
+for touched_hook in \
+  .codex/hooks/bash-guard.sh \
+  .codex/hooks/session-start.sh \
+  .codex/hooks/git-guard.cjs \
+  .codex/hooks/session-start.cjs \
+  .codex/hooks/compact-guard.cjs; do
+  [ -f "$touched_hook" ] && mark_install_touched "$touched_hook"
+done
+if [ "$IS_WINDOWS" = "true" ]; then
+  mark_install_touched ".codex/hooks/git-guard.ps1"
+  mark_install_touched ".codex/hooks/session-start.ps1"
 fi
 
 echo "Installed shell hook scripts"
 
 install_repo_skill sdlc
 write_model_profile
+node "$SCRIPT_DIR/lib/refresh-manifest-hashes.cjs" \
+  ".codex-sdlc/manifest.json" "${INSTALL_TOUCHED_FILES[@]}"
 
 echo ""
 echo "SDLC Wizard for Codex installed."

--- a/lib/merge-hooks.cjs
+++ b/lib/merge-hooks.cjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function usage() {
+  process.stderr.write("Usage: node lib/merge-hooks.cjs [--status] <target-hooks.json> <wizard-hooks.json>\n");
+}
+
+function readJson(filePath, label) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, "utf8").replace(/^\uFEFF/, "");
+  } catch (error) {
+    throw new Error(`Failed to read ${label}: ${error.message}`);
+  }
+
+  let value;
+  try {
+    value = JSON.parse(content);
+  } catch (error) {
+    const invalid = new Error(`${label} is not valid JSON: ${error.message}`);
+    invalid.code = "INVALID_HOOKS_DOCUMENT";
+    throw invalid;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    const invalid = new Error(`${label} must contain a JSON object`);
+    invalid.code = "INVALID_HOOKS_DOCUMENT";
+    throw invalid;
+  }
+  return value;
+}
+
+function validateHooksDocument(value, label) {
+  if (value.hooks === undefined) return;
+  if (!value.hooks || typeof value.hooks !== "object" || Array.isArray(value.hooks)) {
+    const invalid = new Error(`${label}.hooks must be a JSON object`);
+    invalid.code = "INVALID_HOOKS_DOCUMENT";
+    throw invalid;
+  }
+
+  for (const [eventName, entries] of Object.entries(value.hooks)) {
+    if (!Array.isArray(entries)) {
+      const invalid = new Error(`${label}.hooks.${eventName} must be an array`);
+      invalid.code = "INVALID_HOOKS_DOCUMENT";
+      throw invalid;
+    }
+    for (const [entryIndex, entry] of entries.entries()) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry) || !Array.isArray(entry.hooks)) {
+        const invalid = new Error(`${label}.hooks.${eventName}[${entryIndex}] must contain a hooks array`);
+        invalid.code = "INVALID_HOOKS_DOCUMENT";
+        throw invalid;
+      }
+      for (const [hookIndex, hook] of entry.hooks.entries()) {
+        if (!hook || typeof hook !== "object" || Array.isArray(hook)) {
+          const invalid = new Error(`${label}.hooks.${eventName}[${entryIndex}].hooks[${hookIndex}] must be an object`);
+          invalid.code = "INVALID_HOOKS_DOCUMENT";
+          throw invalid;
+        }
+        if (hook.command !== undefined && typeof hook.command !== "string") {
+          const invalid = new Error(`${label}.hooks.${eventName}[${entryIndex}].hooks[${hookIndex}].command must be a string`);
+          invalid.code = "INVALID_HOOKS_DOCUMENT";
+          throw invalid;
+        }
+      }
+    }
+  }
+}
+
+function directoryFoldsCase(directory) {
+  if (process.platform === "win32") return true;
+  if (process.platform !== "darwin") return false;
+
+  const basename = path.basename(directory);
+  const toggledBasename = basename.replace(/[A-Za-z]/, (character) =>
+    character === character.toLowerCase() ? character.toUpperCase() : character.toLowerCase());
+  if (toggledBasename === basename) return false;
+
+  try {
+    const alternate = path.join(path.dirname(directory), toggledBasename);
+    return fs.realpathSync.native(directory) === fs.realpathSync.native(alternate);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function wizardCommandPath(command, foldPathCase) {
+  if (typeof command !== "string") return "";
+  const tokens = command.match(/"[^"\r\n]*"|'[^'\r\n]*'|`[^`\r\n]*`|[^\s]+/g) || [];
+  const unquote = (token) => {
+    const first = token[0];
+    return token.length >= 2 && (first === '"' || first === "'" || first === "`") && token.at(-1) === first
+      ? token.slice(1, -1)
+      : token;
+  };
+  const normalized = tokens.map((token) => {
+    const pathNormalized = unquote(token).replaceAll("\\", "/");
+    return foldPathCase ? pathNormalized.toLowerCase() : pathNormalized;
+  });
+  const isWizardScript = (token) => /^(?:\.\/)?\.codex\/hooks\/(?:git-guard\.(?:cjs|js|ps1)|bash-guard\.sh|session-start\.(?:cjs|js|ps1|sh)|compact-guard\.cjs|sdlc-prompt-check\.sh)$/.test(token || "");
+
+  if (isWizardScript(normalized[0])) return normalized[0];
+
+  const executable = (normalized[0] || "").split("/").at(-1).toLowerCase();
+  if (/^(?:node(?:\.exe)?|bash|sh)$/.test(executable)) {
+    return isWizardScript(normalized[1]) ? normalized[1] : "";
+  }
+  if (/^(?:powershell|pwsh)(?:\.exe)?$/.test(executable)) {
+    const fileFlag = normalized.findIndex((token, index) => index > 0 && token.toLowerCase() === "-file");
+    const script = fileFlag === -1 ? normalized[1] : normalized[fileFlag + 1];
+    return isWizardScript(script) ? script : "";
+  }
+  return "";
+}
+
+function isWizardCommand(command, foldPathCase) {
+  return Boolean(wizardCommandPath(command, foldPathCase));
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function mergeHooks(existing, wizard, foldPathCase) {
+  const merged = clone(existing);
+  merged.hooks = merged.hooks || {};
+
+  for (const [eventName, entries] of Object.entries(merged.hooks)) {
+    const keptEntries = [];
+    for (const entry of entries) {
+      const keptHooks = entry.hooks.filter((hook) => !isWizardCommand(hook.command, foldPathCase));
+      if (keptHooks.length > 0) {
+        keptEntries.push({ ...entry, hooks: keptHooks });
+      }
+    }
+    if (keptEntries.length > 0) {
+      merged.hooks[eventName] = keptEntries;
+    } else {
+      delete merged.hooks[eventName];
+    }
+  }
+
+  for (const [eventName, entries] of Object.entries(wizard.hooks || {})) {
+    merged.hooks[eventName] = [
+      ...(merged.hooks[eventName] || []),
+      ...clone(entries),
+    ];
+  }
+
+  return merged;
+}
+
+function wizardSurface(value, foldPathCase) {
+  const surface = {};
+  for (const [eventName, entries] of Object.entries(value.hooks || {})) {
+    const wizardEntries = [];
+    for (const entry of entries) {
+      const wizardHooks = entry.hooks.filter((hook) => isWizardCommand(hook.command, foldPathCase));
+      if (wizardHooks.length > 0) {
+        wizardEntries.push({ ...entry, hooks: wizardHooks });
+      }
+    }
+    if (wizardEntries.length > 0) surface[eventName] = wizardEntries;
+  }
+  return surface;
+}
+
+function wizardSurfaceMatches(existing, wizard, foldPathCase) {
+  const sortEvents = (hooks) => Object.fromEntries(
+    Object.entries(hooks).sort(([left], [right]) => left.localeCompare(right)),
+  );
+  return JSON.stringify(sortEvents(wizardSurface(existing, foldPathCase))) ===
+    JSON.stringify(sortEvents(wizard.hooks || {}));
+}
+
+function writeAtomically(filePath, value) {
+  const directory = path.dirname(filePath);
+  const mode = fs.existsSync(filePath)
+    ? fs.statSync(filePath).mode & 0o777
+    : 0o666 & ~process.umask();
+  fs.mkdirSync(directory, { recursive: true });
+  const temporary = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+      flag: "wx",
+      mode,
+    });
+    fs.chmodSync(temporary, mode);
+    fs.renameSync(temporary, filePath);
+  } finally {
+    try {
+      fs.unlinkSync(temporary);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const statusOnly = args[0] === "--status";
+  if (statusOnly) args.shift();
+  if (args.length !== 2) {
+    usage();
+    process.exitCode = 2;
+    return;
+  }
+
+  const [targetPath, wizardPath] = args;
+  const wizard = readJson(wizardPath, wizardPath);
+  validateHooksDocument(wizard, wizardPath);
+
+  const exists = fs.existsSync(targetPath);
+  let existing = {};
+  if (exists) {
+    try {
+      existing = readJson(targetPath, targetPath);
+      validateHooksDocument(existing, targetPath);
+    } catch (error) {
+      if (statusOnly && error.code === "INVALID_HOOKS_DOCUMENT") {
+        process.stdout.write("target-broken\n");
+        return;
+      }
+      throw error;
+    }
+  }
+  const foldPathCase = directoryFoldsCase(path.dirname(targetPath));
+  const changed = !exists || !wizardSurfaceMatches(existing, wizard, foldPathCase);
+
+  if (statusOnly) {
+    process.stdout.write(changed ? "merge\n" : "match\n");
+    return;
+  }
+  if (changed) writeAtomically(targetPath, mergeHooks(existing, wizard, foldPathCase));
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`Error: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { directoryFoldsCase, isWizardCommand, validateHooksDocument, wizardCommandPath };

--- a/lib/refresh-manifest-hashes.cjs
+++ b/lib/refresh-manifest-hashes.cjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function hash(filePath) {
+  return `sha256:${crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex")}`;
+}
+
+function writeTextAtomically(filePath, value) {
+  const directory = path.dirname(filePath);
+  const mode = fs.existsSync(filePath)
+    ? fs.statSync(filePath).mode & 0o777
+    : 0o666 & ~process.umask();
+  const temporary = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporary, value, { flag: "wx", mode });
+    fs.chmodSync(temporary, mode);
+    fs.renameSync(temporary, filePath);
+  } finally {
+    try {
+      fs.unlinkSync(temporary);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function refreshProfileGuidance(manifest, touchedFiles, selectedProfile, baselineReasoning) {
+  const agentsPath = "AGENTS.md";
+  const previousProfile = manifest.model_profile?.selected_profile;
+  const trackedHash = manifest.managed_files?.[agentsPath];
+  if (
+    typeof previousProfile !== "string" ||
+    previousProfile === "" ||
+    previousProfile === selectedProfile ||
+    typeof trackedHash !== "string" ||
+    !fs.existsSync(agentsPath) ||
+    hash(agentsPath) !== trackedHash
+  ) {
+    return false;
+  }
+
+  const original = fs.readFileSync(agentsPath, "utf8");
+  const selectedProfilePattern = /^(- Selected profile: )(`?)[^`\r\n]+(`?)$/m;
+  const baselineReasoningPattern = /^- Baseline reasoning: `[^`\r\n]+`$/m;
+  if (!selectedProfilePattern.test(original) || !baselineReasoningPattern.test(original)) {
+    return false;
+  }
+  let updated = original.replace(
+    selectedProfilePattern,
+    (_match, prefix, opening, closing) => `${prefix}${opening}${selectedProfile}${closing}`,
+  );
+  updated = updated.replace(
+    baselineReasoningPattern,
+    `- Baseline reasoning: \`${baselineReasoning}\``,
+  );
+  updated = updated.replace(
+    /^(- Start work at the selected )`[^`\r\n]+`( baseline\..*)$/m,
+    `$1\`${baselineReasoning}\`$2`,
+  );
+
+  if (updated === original) {
+    return false;
+  }
+  writeTextAtomically(agentsPath, updated);
+  touchedFiles.add(agentsPath);
+  return true;
+}
+
+function synchronizeModelProfile(manifest, touchedFiles) {
+  const profilePath = ".codex-sdlc/model-profile.json";
+  if (!touchedFiles.has(profilePath) || !fs.existsSync(profilePath)) return false;
+
+  const profile = JSON.parse(fs.readFileSync(profilePath, "utf8"));
+  const selectedProfile = profile?.selected_profile;
+  if (typeof selectedProfile !== "string" || selectedProfile === "") {
+    throw new Error(`${profilePath}.selected_profile must contain a nonempty string`);
+  }
+
+  const next = {
+    ...(manifest.model_profile || {}),
+    selected_profile: selectedProfile,
+  };
+  if (Number.isInteger(profile.schema_version)) {
+    next.policy_schema_version = profile.schema_version;
+  }
+  const baselineReasoning = profile.profiles?.[selectedProfile]?.main_reasoning;
+  if (typeof baselineReasoning !== "string" || baselineReasoning === "") {
+    throw new Error(`${profilePath} does not define main_reasoning for ${selectedProfile}`);
+  }
+  next.baseline_reasoning = baselineReasoning;
+
+  const guidanceChanged = refreshProfileGuidance(
+    manifest,
+    touchedFiles,
+    selectedProfile,
+    next.baseline_reasoning,
+  );
+  const changed = guidanceChanged || JSON.stringify(manifest.model_profile || {}) !== JSON.stringify(next);
+  manifest.model_profile = next;
+  return changed;
+}
+
+function writeAtomically(filePath, value) {
+  const directory = path.dirname(filePath);
+  const mode = fs.existsSync(filePath)
+    ? fs.statSync(filePath).mode & 0o777
+    : 0o666 & ~process.umask();
+  const temporary = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+      flag: "wx",
+      mode,
+    });
+    fs.chmodSync(temporary, mode);
+    fs.renameSync(temporary, filePath);
+  } finally {
+    try {
+      fs.unlinkSync(temporary);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+function main() {
+  const [manifestPath, ...touchedFiles] = process.argv.slice(2);
+  if (!manifestPath) {
+    process.stderr.write("Usage: node lib/refresh-manifest-hashes.cjs <manifest.json> [touched-file ...]\n");
+    process.exitCode = 2;
+    return;
+  }
+  if (!fs.existsSync(manifestPath)) return;
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error(`${manifestPath} must contain a JSON object`);
+  }
+  const managed = manifest.managed_files;
+  if (!managed || typeof managed !== "object" || Array.isArray(managed)) {
+    throw new Error(`${manifestPath}.managed_files must contain a JSON object`);
+  }
+
+  const touchedFileSet = new Set(touchedFiles);
+  let changed = synchronizeModelProfile(manifest, touchedFileSet);
+  for (const filePath of touchedFileSet) {
+    if (!fs.existsSync(filePath)) {
+      if (Object.prototype.hasOwnProperty.call(managed, filePath)) {
+        delete managed[filePath];
+        changed = true;
+      }
+      continue;
+    }
+    const currentHash = hash(filePath);
+    if (managed[filePath] !== currentHash) {
+      managed[filePath] = currentHash;
+      changed = true;
+    }
+  }
+  if (changed) writeAtomically(manifestPath, manifest);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`Error: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-sdlc-wizard",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "description": "Codex SDLC plugin, adaptive setup wizard, and maintenance CLI",
   "license": "MIT",
   "funding": {

--- a/skills/codex-sdlc-wizard/agents/openai.yaml
+++ b/skills/codex-sdlc-wizard/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Codex SDLC Wizard"
-  short_description: "Install Codex SDLC guardrails"
+  display_name: "Install SDLC Guardrails"
+  short_description: "Set up or repair repo SDLC"
   default_prompt: "Use $codex-sdlc-wizard to install or update Codex SDLC enforcement in this repository."

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -1855,6 +1855,576 @@ test_install_backs_up_hooks_json() {
     fi
 }
 
+test_install_merges_existing_hooks_json() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.codex"
+    cat > "$tmpdir/.codex/hooks.json" <<'EOF'
+{
+  "customSetting": "keep-me",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .custom/session.cjs"
+          },
+          {
+            "type": "command",
+            "command": "node .codex/hooks/session-start.cjs"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^Write$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .custom/guard.cjs"
+          }
+        ]
+      },
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.codex/hooks/bash-guard.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .custom/post-tool.cjs"
+          },
+          {
+            "type": "command",
+            "command": "node .custom/audit.cjs .codex/hooks/git-guard.cjs"
+          },
+          {
+            "type": "command",
+            "command": "node .codex/hooks/Git-Guard.cjs"
+          },
+          {
+            "type": "command",
+            "command": "pwsh -FILE .codex/hooks/git-guard.ps1"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/sdlc-prompt-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+    HOOKS_PATH="$tmpdir/.codex/hooks.json" node <<'NODE'
+const fs = require("fs");
+const hooksPath = process.env.HOOKS_PATH;
+fs.writeFileSync(hooksPath, `\uFEFF${fs.readFileSync(hooksPath, "utf8")}`);
+NODE
+    chmod 644 "$tmpdir/.codex/hooks.json"
+
+    local valid=true
+    (umask 077; cd "$tmpdir" && CODEX_HOME="$tmpdir/.codex-home" bash "$REPO_DIR/install.sh" >/dev/null 2>&1) || valid=false
+    (umask 077; cd "$tmpdir" && CODEX_HOME="$tmpdir/.codex-home" bash "$REPO_DIR/install.sh" >/dev/null 2>&1) || valid=false
+    [ "$(node "$REPO_DIR/lib/merge-hooks.cjs" --status "$tmpdir/.codex/hooks.json" "$REPO_DIR/.codex/unix-hooks.json")" = "match" ] || valid=false
+
+    HOOKS_PATH="$tmpdir/.codex/hooks.json" \
+    EXPECT_MODE_CHECK="$([ "$IS_WINDOWS" = "false" ] && echo true || echo false)" \
+    node <<'NODE' || valid=false
+const fs = require("fs");
+const path = require("path");
+const data = JSON.parse(fs.readFileSync(process.env.HOOKS_PATH, "utf8"));
+const commands = Object.values(data.hooks || {}).flatMap((entries) =>
+  entries.flatMap((entry) => (entry.hooks || []).map((hook) => hook.command))
+);
+const expectedOnce = [
+  "node .codex/hooks/git-guard.cjs",
+  "node .codex/hooks/session-start.cjs",
+  "node .codex/hooks/compact-guard.cjs",
+];
+if (data.customSetting !== "keep-me") process.exit(1);
+if (!commands.includes("node .custom/guard.cjs")) process.exit(1);
+if (!commands.includes("node .custom/post-tool.cjs")) process.exit(1);
+if (!commands.includes("node .custom/audit.cjs .codex/hooks/git-guard.cjs")) process.exit(1);
+const hasCaseDistinctHook = commands.includes("node .codex/hooks/Git-Guard.cjs");
+const hooksDirectory = path.dirname(process.env.HOOKS_PATH);
+let foldsCase = process.platform === "win32";
+if (process.platform === "darwin") {
+  try {
+    const alternate = path.join(path.dirname(hooksDirectory), ".CODEX");
+    foldsCase = fs.realpathSync.native(hooksDirectory) === fs.realpathSync.native(alternate);
+  } catch (_error) {
+    foldsCase = false;
+  }
+}
+
+if (foldsCase === hasCaseDistinctHook) process.exit(1);
+if (commands.includes("pwsh -FILE .codex/hooks/git-guard.ps1")) process.exit(1);
+if (!commands.includes("node .custom/session.cjs")) process.exit(1);
+if (commands.some((command) => /bash-guard|sdlc-prompt-check/.test(command))) process.exit(1);
+for (const command of expectedOnce) {
+  const expectedCount = command.includes("compact-guard") ? 2 : 1;
+  if (commands.filter((candidate) => candidate === command).length !== expectedCount) process.exit(1);
+}
+if (process.env.EXPECT_MODE_CHECK === "true" && (fs.statSync(process.env.HOOKS_PATH).mode & 0o777) !== 0o644) process.exit(1);
+NODE
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "install.sh preserves host hooks and replaces wizard-owned hook entries idempotently"
+    else
+        fail "install.sh overwrote host hooks or duplicated wizard-owned hook entries"
+    fi
+}
+
+test_merge_fresh_file_honors_restrictive_umask() {
+    if [ "$IS_WINDOWS" = "true" ]; then
+        pass "fresh hook merge umask behavior is POSIX-only"
+        return
+    fi
+
+    local tmpdir valid=true
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.codex"
+
+    (
+        umask 077
+        node "$REPO_DIR/lib/merge-hooks.cjs" \
+            "$tmpdir/.codex/hooks.json" "$REPO_DIR/.codex/unix-hooks.json"
+    ) >/dev/null 2>&1 || valid=false
+    HOOKS_PATH="$tmpdir/.codex/hooks.json" node <<'NODE' || valid=false
+const fs = require("fs");
+if ((fs.statSync(process.env.HOOKS_PATH).mode & 0o777) !== 0o600) process.exit(1);
+NODE
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "fresh hook merge honors a restrictive process umask"
+    else
+        fail "fresh hook merge widened permissions beyond the process umask"
+    fi
+}
+
+test_check_passes_merge_helper_as_node_argument() {
+    if grep -Fq 'node - "$SCRIPT_DIR/lib/merge-hooks.cjs"' "$REPO_DIR/check.sh" \
+        && grep -Fq 'require(process.argv[2])' "$REPO_DIR/check.sh"; then
+        pass "check passes the merge helper through MSYS-convertible Node argv"
+    else
+        fail "check passes the merge helper through an unconverted environment path"
+    fi
+}
+
+test_check_reports_non_object_hooks_as_broken() {
+    local tmpdir output status valid=true
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.codex" "$tmpdir/.codex-sdlc"
+    printf '%s\n' 'null' > "$tmpdir/.codex/hooks.json"
+    cat > "$tmpdir/.codex-sdlc/manifest.json" <<'EOF'
+{
+  "managed_files": {
+    ".codex/hooks.json": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}
+
+EOF
+
+    set +e
+    output=$(cd "$tmpdir" && bash "$REPO_DIR/check.sh" 2>/dev/null)
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || valid=false
+    CHECK_OUTPUT="$output" node <<'NODE' || valid=false
+const data = JSON.parse(process.env.CHECK_OUTPUT);
+if (data.managed_files?.[".codex/hooks.json"]?.status !== "drift / broken") process.exit(1);
+NODE
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "check reports non-object hooks.json as broken"
+    else
+        fail "check crashed on a non-object hooks.json document"
+    fi
+}
+
+test_check_reports_structurally_invalid_hooks_as_broken() {
+    local tmpdir output status valid=true
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.codex" "$tmpdir/.codex-sdlc"
+    printf '%s\n' '{"hooks":[]}' > "$tmpdir/.codex/hooks.json"
+    cat > "$tmpdir/.codex-sdlc/manifest.json" <<'EOF'
+{
+  "managed_files": {
+    ".codex/hooks.json": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}
+EOF
+
+    set +e
+    output=$(cd "$tmpdir" && bash "$REPO_DIR/check.sh" 2>/dev/null)
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || valid=false
+    CHECK_OUTPUT="$output" node <<'NODE' || valid=false
+const data = JSON.parse(process.env.CHECK_OUTPUT);
+if (data.managed_files?.[".codex/hooks.json"]?.status !== "drift / broken") process.exit(1);
+NODE
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "check reports structurally invalid hooks.json as broken"
+    else
+        fail "check mislabeled structurally invalid hooks.json as customized"
+    fi
+}
+
+test_merge_status_distinguishes_broken_target_from_bad_template() {
+    local tmpdir output status before valid=true
+    tmpdir=$(mktemp -d)
+    printf '%s\n' '{"hooks":{}}' > "$tmpdir/target.json"
+    printf '%s\n' '{ malformed template' > "$tmpdir/template.json"
+    before=$(cat "$tmpdir/target.json")
+
+    set +e
+    output=$(node "$REPO_DIR/lib/merge-hooks.cjs" --status "$tmpdir/target.json" "$tmpdir/template.json" 2>&1)
+    status=$?
+    set -e
+    [ "$status" -ne 0 ] || valid=false
+    [ "$(cat "$tmpdir/target.json")" = "$before" ] || valid=false
+    echo "$output" | grep -Fq 'template.json' || valid=false
+
+    printf '%s\n' '{ malformed target' > "$tmpdir/target.json"
+    cp "$REPO_DIR/.codex/unix-hooks.json" "$tmpdir/template.json"
+    output=$(node "$REPO_DIR/lib/merge-hooks.cjs" --status "$tmpdir/target.json" "$tmpdir/template.json" 2>&1) || valid=false
+    [ "$output" = "target-broken" ] || valid=false
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "merge status distinguishes a broken target from a bad template"
+    else
+        fail "merge status could not distinguish target corruption from package failure"
+    fi
+}
+
+test_install_rejects_malformed_hooks_without_overwrite() {
+    local tmpdir before after guard_before guard_after output status valid=true
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.codex/hooks"
+    printf '%s\n' '{ malformed hooks json' > "$tmpdir/.codex/hooks.json"
+    printf '%s\n' 'USER CUSTOM GUARD' > "$tmpdir/.codex/hooks/git-guard.cjs"
+    before=$(cat "$tmpdir/.codex/hooks.json")
+    guard_before=$(cat "$tmpdir/.codex/hooks/git-guard.cjs")
+
+    set +e
+    output=$(cd "$tmpdir" && CODEX_HOME="$tmpdir/.codex-home" bash "$REPO_DIR/install.sh" 2>&1)
+    status=$?
+    set -e
+    after=$(cat "$tmpdir/.codex/hooks.json")
+    guard_after=$(cat "$tmpdir/.codex/hooks/git-guard.cjs")
+
+    [ "$status" -ne 0 ] || valid=false
+    [ "$after" = "$before" ] || valid=false
+    [ "$guard_after" = "$guard_before" ] || valid=false
+    [ ! -e "$tmpdir/.codex/config.toml" ] || valid=false
+    [ ! -e "$tmpdir/.codex-home/skills/setup-wizard" ] || valid=false
+    echo "$output" | grep -Eqi 'hooks.json|JSON|parse' || valid=false
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "install.sh rejects malformed hooks.json without overwriting it"
+    else
+        fail "install.sh did not fail closed on malformed hooks.json"
+    fi
+}
+
+test_install_refreshes_unmodified_agents_for_profile_switch() {
+    local tmpdir output valid=true
+    tmpdir=$(mktemp -d)
+    echo '{"name":"profile-switch","scripts":{"test":"jest"}}' > "$tmpdir/package.json"
+    mkdir -p "$tmpdir/src"
+
+    (
+        umask 077 && cd "$tmpdir" && \
+        CODEX_HOME="$tmpdir/.codex-home" \
+        CODEX_SDLC_DISABLE_REASONING=1 \
+        bash "$REPO_DIR/setup.sh" --yes --model-profile mixed >/dev/null 2>&1
+    ) || valid=false
+
+    cat > "$tmpdir/AGENTS.md" <<'EOF'
+# SDLC Enforcement
+
+- Selected profile: `mixed`
+- Baseline reasoning: `medium`
+EOF
+    MANIFEST_PATH="$tmpdir/.codex-sdlc/manifest.json" AGENTS_PATH="$tmpdir/AGENTS.md" node <<'NODE'
+const crypto = require("crypto");
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, "utf8"));
+manifest.managed_files["AGENTS.md"] = `sha256:${crypto.createHash("sha256").update(fs.readFileSync(process.env.AGENTS_PATH)).digest("hex")}`;
+fs.writeFileSync(process.env.MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+
+    (
+        umask 077 && cd "$tmpdir" && \
+        CODEX_HOME="$tmpdir/.codex-home" \
+        bash "$REPO_DIR/install.sh" --model-profile maximum >/dev/null 2>&1
+    ) || valid=false
+    output=$(cd "$tmpdir" && bash "$REPO_DIR/check.sh" 2>/dev/null)
+
+    grep -Fq -- '- Selected profile: `maximum`' "$tmpdir/AGENTS.md" || valid=false
+    grep -Fq -- '- Baseline reasoning: `high`' "$tmpdir/AGENTS.md" || valid=false
+    ! grep -Fq -- '- Selected profile: mixed' "$tmpdir/AGENTS.md" || valid=false
+    CHECK_OUTPUT="$output" node <<'NODE' || valid=false
+const data = JSON.parse(process.env.CHECK_OUTPUT);
+if (data.managed_files?.["AGENTS.md"]?.status !== "match") process.exit(1);
+NODE
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "install refreshes unmodified AGENTS guidance when the selected profile changes"
+    else
+        fail "install left trusted AGENTS guidance on the old selected profile"
+    fi
+}
+
+test_profile_guidance_refresh_rejects_missing_reasoning() {
+    local tmpdir status valid=true
+    tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.codex-sdlc"
+    cat > "$tmpdir/AGENTS.md" <<'EOF'
+- Selected profile: `mixed`
+- Baseline reasoning: `medium`
+EOF
+    ROOT="$tmpdir" node <<'NODE'
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const root = process.env.ROOT;
+const agents = fs.readFileSync(path.join(root, "AGENTS.md"));
+fs.writeFileSync(path.join(root, ".codex-sdlc", "manifest.json"), `${JSON.stringify({
+  model_profile: { selected_profile: "mixed" },
+  managed_files: {
+    "AGENTS.md": `sha256:${crypto.createHash("sha256").update(agents).digest("hex")}`,
+    ".codex-sdlc/model-profile.json": "sha256:old",
+  },
+}, null, 2)}\n`);
+fs.writeFileSync(path.join(root, ".codex-sdlc", "model-profile.json"), '{"selected_profile":"maximum"}\n');
+NODE
+
+    set +e
+    (cd "$tmpdir" && node "$REPO_DIR/lib/refresh-manifest-hashes.cjs" \
+        .codex-sdlc/manifest.json .codex-sdlc/model-profile.json) >/dev/null 2>&1
+    status=$?
+    set -e
+
+    [ "$status" -ne 0 ] || valid=false
+    ! grep -Fq '`undefined`' "$tmpdir/AGENTS.md" || valid=false
+    grep -Fq -- '- Selected profile: `mixed`' "$tmpdir/AGENTS.md" || valid=false
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "profile guidance refresh rejects metadata without a reasoning baseline"
+    else
+        fail "profile guidance refresh wrote an undefined reasoning baseline"
+    fi
+}
+
+test_profile_guidance_refresh_handles_legacy_and_partial_guidance() {
+    local legacy_dir partial_dir legacy_before partial_before valid=true
+    legacy_dir=$(mktemp -d)
+    partial_dir=$(mktemp -d)
+
+    for target_dir in "$legacy_dir" "$partial_dir"; do
+        mkdir -p "$target_dir/.codex-sdlc"
+    done
+
+    cat > "$legacy_dir/AGENTS.md" <<'EOF'
+- Selected profile: `maximum`
+- Baseline reasoning: `high`
+EOF
+    cat > "$partial_dir/AGENTS.md" <<'EOF'
+- Selected profile: `mixed`
+EOF
+    legacy_before=$(cat "$legacy_dir/AGENTS.md")
+    partial_before=$(cat "$partial_dir/AGENTS.md")
+
+    ROOT="$legacy_dir" PREVIOUS_PROFILE="" node <<'NODE'
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const root = process.env.ROOT;
+const agents = fs.readFileSync(path.join(root, "AGENTS.md"));
+fs.writeFileSync(path.join(root, ".codex-sdlc", "manifest.json"), `${JSON.stringify({
+  managed_files: {
+    "AGENTS.md": `sha256:${crypto.createHash("sha256").update(agents).digest("hex")}`,
+    ".codex-sdlc/model-profile.json": "sha256:old",
+  },
+}, null, 2)}\n`);
+fs.writeFileSync(path.join(root, ".codex-sdlc", "model-profile.json"), `${JSON.stringify({
+  schema_version: 2,
+  selected_profile: "maximum",
+  profiles: { maximum: { main_reasoning: "high" } },
+})}\n`);
+NODE
+    ROOT="$partial_dir" node <<'NODE'
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const root = process.env.ROOT;
+const agents = fs.readFileSync(path.join(root, "AGENTS.md"));
+fs.writeFileSync(path.join(root, ".codex-sdlc", "manifest.json"), `${JSON.stringify({
+  model_profile: { selected_profile: "mixed" },
+  managed_files: {
+    "AGENTS.md": `sha256:${crypto.createHash("sha256").update(agents).digest("hex")}`,
+    ".codex-sdlc/model-profile.json": "sha256:old",
+  },
+}, null, 2)}\n`);
+fs.writeFileSync(path.join(root, ".codex-sdlc", "model-profile.json"), `${JSON.stringify({
+  schema_version: 2,
+  selected_profile: "maximum",
+  profiles: { maximum: { main_reasoning: "high" } },
+})}\n`);
+NODE
+
+    (cd "$legacy_dir" && node "$REPO_DIR/lib/refresh-manifest-hashes.cjs" \
+        .codex-sdlc/manifest.json .codex-sdlc/model-profile.json) >/dev/null 2>&1 || valid=false
+    (cd "$partial_dir" && node "$REPO_DIR/lib/refresh-manifest-hashes.cjs" \
+        .codex-sdlc/manifest.json .codex-sdlc/model-profile.json) >/dev/null 2>&1 || valid=false
+
+    [ "$(cat "$legacy_dir/AGENTS.md")" = "$legacy_before" ] || valid=false
+    [ "$(cat "$partial_dir/AGENTS.md")" = "$partial_before" ] || valid=false
+    MANIFEST_PATH="$legacy_dir/.codex-sdlc/manifest.json" node <<'NODE' || valid=false
+const manifest = require(process.env.MANIFEST_PATH);
+if (manifest.model_profile?.selected_profile !== "maximum") process.exit(1);
+if (manifest.model_profile?.baseline_reasoning !== "high") process.exit(1);
+NODE
+    rm -rf "$legacy_dir" "$partial_dir"
+
+    if [ "$valid" = "true" ]; then
+        pass "profile refresh synchronizes legacy metadata without partially rewriting guidance"
+    else
+        fail "profile refresh failed or partially rewrote legacy guidance"
+    fi
+}
+
+test_install_refreshes_only_touched_manifest_hashes() {
+    local tmpdir output valid=true
+    tmpdir=$(mktemp -d)
+    echo '{"name":"manifest-refresh","scripts":{"test":"jest"}}' > "$tmpdir/package.json"
+    mkdir -p "$tmpdir/src"
+
+    (
+        cd "$tmpdir" && \
+        CODEX_HOME="$tmpdir/.codex-home" \
+        CODEX_SDLC_DISABLE_REASONING=1 \
+        bash "$REPO_DIR/setup.sh" --yes --model-profile mixed >/dev/null 2>&1
+    ) || valid=false
+
+    printf '%s\n' 'legacy bash guard' > "$tmpdir/.codex/hooks/bash-guard.sh"
+    printf '%s\n' 'legacy PowerShell guard' > "$tmpdir/.codex/hooks/git-guard.ps1"
+    printf '%s\n' 'legacy JavaScript guard' > "$tmpdir/.codex/hooks/git-guard.js"
+    printf '%s\n' 'legacy JavaScript session hook' > "$tmpdir/.codex/hooks/session-start.js"
+    HOOKS_PATH="$tmpdir/.codex/hooks.json" node <<'NODE'
+const fs = require("fs");
+const hooksPath = process.env.HOOKS_PATH;
+const hooks = JSON.parse(fs.readFileSync(hooksPath, "utf8"));
+hooks.hostSetting = "preserve-without-adopting";
+fs.writeFileSync(hooksPath, `${JSON.stringify(hooks, null, 2)}\n`);
+NODE
+    cat > "$tmpdir/.codex/config.toml" <<'EOF'
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
+
+[features]
+hooks = false
+EOF
+    printf '\nUSER CUSTOM AGENTS CONTENT\n' >> "$tmpdir/AGENTS.md"
+
+    MANIFEST_PATH="$tmpdir/.codex-sdlc/manifest.json" \
+    BASH_GUARD_PATH="$tmpdir/.codex/hooks/bash-guard.sh" \
+    PS_GUARD_PATH="$tmpdir/.codex/hooks/git-guard.ps1" \
+    LEGACY_GIT_GUARD_PATH="$tmpdir/.codex/hooks/git-guard.js" \
+    LEGACY_SESSION_PATH="$tmpdir/.codex/hooks/session-start.js" \
+    CONFIG_PATH="$tmpdir/.codex/config.toml" \
+    node <<'NODE'
+const crypto = require("crypto");
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, "utf8"));
+const hash = (filePath) => `sha256:${crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex")}`;
+delete manifest.managed_files[".codex/hooks/compact-guard.cjs"];
+manifest.managed_files[".codex/hooks/bash-guard.sh"] = hash(process.env.BASH_GUARD_PATH);
+manifest.managed_files[".codex/hooks/git-guard.ps1"] = hash(process.env.PS_GUARD_PATH);
+manifest.managed_files[".codex/hooks/git-guard.js"] = hash(process.env.LEGACY_GIT_GUARD_PATH);
+manifest.managed_files[".codex/hooks/session-start.js"] = hash(process.env.LEGACY_SESSION_PATH);
+manifest.managed_files[".codex/config.toml"] = hash(process.env.CONFIG_PATH);
+fs.writeFileSync(process.env.MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+    chmod 644 "$tmpdir/.codex-sdlc/manifest.json"
+    if [ "$IS_WINDOWS" = "false" ]; then
+        printf '%s\n' 'USER CUSTOM POWERSHELL GUARD' >> "$tmpdir/.codex/hooks/git-guard.ps1"
+    fi
+
+    (
+        umask 077 && cd "$tmpdir" && \
+        CODEX_HOME="$tmpdir/.codex-home" \
+        bash "$REPO_DIR/install.sh" --model-profile maximum >/dev/null 2>&1
+    ) || valid=false
+    output=$(cd "$tmpdir" && bash "$REPO_DIR/check.sh" 2>/dev/null)
+
+    CHECK_OUTPUT="$output" EXPECT_POWERSHELL_MATCH="$IS_WINDOWS" node <<'NODE' || valid=false
+const data = JSON.parse(process.env.CHECK_OUTPUT);
+for (const file of [
+  ".codex/hooks/bash-guard.sh",
+  ".codex/hooks/compact-guard.cjs",
+  ".codex/config.toml",
+]) {
+  if (data.managed_files?.[file]?.status !== "match") process.exit(1);
+}
+const expectedPowerShellStatus = process.env.EXPECT_POWERSHELL_MATCH === "true" ? "match" : "customized";
+if (data.managed_files?.[".codex/hooks/git-guard.ps1"]?.status !== expectedPowerShellStatus) process.exit(1);
+if (data.managed_files?.[".codex/hooks.json"]?.status !== "customized") process.exit(1);
+if (data.managed_files?.["AGENTS.md"]?.status !== "customized") process.exit(1);
+NODE
+    MANIFEST_PATH="$tmpdir/.codex-sdlc/manifest.json" EXPECT_POSIX="$([ "$IS_WINDOWS" = "false" ] && echo true || echo false)" node <<'NODE' || valid=false
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, "utf8"));
+if (manifest.model_profile?.selected_profile !== "maximum") process.exit(1);
+if (manifest.model_profile?.baseline_reasoning !== "high") process.exit(1);
+if (Object.prototype.hasOwnProperty.call(manifest.managed_files, ".codex/hooks/git-guard.js")) process.exit(1);
+if (Object.prototype.hasOwnProperty.call(manifest.managed_files, ".codex/hooks/session-start.js")) process.exit(1);
+if (process.env.EXPECT_POSIX === "true" && (fs.statSync(process.env.MANIFEST_PATH).mode & 0o777) !== 0o644) process.exit(1);
+NODE
+    grep -Fq 'refresh-manifest-hashes.cjs' "$REPO_DIR/install.ps1" || valid=false
+    grep -Fq 'merge-hooks.cjs") --status' "$REPO_DIR/install.ps1" || valid=false
+    grep -Fq 'Add-TouchedFile -Path ".agents/skills/$Name/SKILL.md"' "$REPO_DIR/install.ps1" || valid=false
+    grep -Fq '$touchedFileArgs = $touchedFiles.ToArray()' "$REPO_DIR/install.ps1" || valid=false
+    grep -Fq '@touchedFileArgs' "$REPO_DIR/install.ps1" || valid=false
+    rm -rf "$tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "install refreshes hashes only for artifacts it touched on shell and PowerShell paths"
+    else
+        fail "install left touched manifest hashes stale or adopted untouched custom content"
+    fi
+}
+
 test_agents_md_size() {
     local size
     size=$(wc -c < "$REPO_DIR/AGENTS.md" 2>/dev/null | tr -d ' ')
@@ -2589,6 +3159,17 @@ test_install_creates_skill
 test_install_keeps_skill_backups_out_of_skills_and_prunes_legacy_sdlc
 test_install_merges_config
 test_install_backs_up_hooks_json
+test_install_merges_existing_hooks_json
+test_merge_fresh_file_honors_restrictive_umask
+test_check_passes_merge_helper_as_node_argument
+test_install_rejects_malformed_hooks_without_overwrite
+test_check_reports_non_object_hooks_as_broken
+test_check_reports_structurally_invalid_hooks_as_broken
+test_merge_status_distinguishes_broken_target_from_bad_template
+test_install_refreshes_unmodified_agents_for_profile_switch
+test_profile_guidance_refresh_rejects_missing_reasoning
+test_profile_guidance_refresh_handles_legacy_and_partial_guidance
+test_install_refreshes_only_touched_manifest_hashes
 test_agents_md_size
 test_setup_skill_has_confidence_setup_contract
 test_update_skill_has_idempotent_update_contract

--- a/tests/test-npm.sh
+++ b/tests/test-npm.sh
@@ -85,6 +85,7 @@ test_npm_pack_includes_runtime_files() {
     local has_setup=true
     local has_hooks=true
     local has_bin=true
+    local has_runtime_helpers=true
     local has_plugin_skill=true
     local avoids_legacy_root_skill=true
     local has_plugin_manifest=true
@@ -101,6 +102,7 @@ test_npm_pack_includes_runtime_files() {
         has_setup=false
         has_hooks=false
         has_bin=false
+        has_runtime_helpers=false
         has_plugin_skill=false
         avoids_legacy_root_skill=false
         has_plugin_manifest=false
@@ -116,6 +118,8 @@ test_npm_pack_includes_runtime_files() {
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === ".codex/hooks/session-start.cjs") ? "yes" : ""')" = "yes" ] || has_hooks=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === ".codex/hooks/compact-guard.cjs") ? "yes" : ""')" = "yes" ] || has_hooks=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "bin/codex-sdlc-wizard.js") ? "yes" : ""')" = "yes" ] || has_bin=false
+        [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "lib/merge-hooks.cjs") ? "yes" : ""')" = "yes" ] || has_runtime_helpers=false
+        [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "lib/refresh-manifest-hashes.cjs") ? "yes" : ""')" = "yes" ] || has_runtime_helpers=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "skills/codex-sdlc-wizard/SKILL.md") ? "yes" : ""')" = "yes" ] || has_plugin_skill=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "skills/codex-sdlc-wizard/agents/openai.yaml") ? "yes" : ""')" = "yes" ] || has_plugin_skill=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "SKILL.md") ? "yes" : ""')" = "yes" ] && avoids_legacy_root_skill=false
@@ -136,6 +140,7 @@ test_npm_pack_includes_runtime_files() {
        [ "$has_setup" = "true" ] &&
        [ "$has_hooks" = "true" ] &&
        [ "$has_bin" = "true" ] &&
+       [ "$has_runtime_helpers" = "true" ] &&
        [ "$has_plugin_skill" = "true" ] &&
        [ "$avoids_legacy_root_skill" = "true" ] &&
        [ "$has_plugin_manifest" = "true" ] &&
@@ -446,6 +451,106 @@ EOF
     fi
 }
 
+test_failed_optional_handoff_keeps_successful_install_successful() {
+    local ws fakebin codex_home input_file output package_version status valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
+    fakebin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-bin.XXXXXX")
+    codex_home=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-home.XXXXXX")
+    input_file="$ws/handoff-input.txt"
+
+    printf '%s' '{"name":"handoff-failure","scripts":{"test":"npm test"}}' > "$ws/package.json"
+    printf '\n' > "$input_file"
+
+    cat > "$fakebin/codex" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  echo "codex-cli 0.144.0"
+  exit 0
+fi
+echo "Error loading config.toml: unrelated user config failure" >&2
+exit 42
+EOF
+    chmod +x "$fakebin/codex"
+
+    set +e
+    output=$(
+        cd "$ws" && \
+        CODEX_HOME="$codex_home" \
+        CODEX_SDLC_CODEX_BIN="$fakebin/codex" \
+        CODEX_SDLC_DISABLE_REASONING=1 \
+        PATH="$fakebin:$PATH" \
+        node "$REPO_DIR/bin/codex-sdlc-wizard.js" --model-profile mixed --goals < "$input_file" 2>&1
+    )
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || valid=false
+    [ -f "$ws/.codex/config.toml" ] || valid=false
+    [ -f "$ws/.agents/skills/sdlc/SKILL.md" ] || valid=false
+    echo "$output" | grep -Eqi 'artifacts.*installed|install.*succeeded' || valid=false
+    echo "$output" | grep -Eqi 'handoff.*failed|could not.*handoff|Codex.*exited' || valid=false
+    package_version=$(node -p "require('$REPO_DIR/package.json').version")
+    echo "$output" | grep -Fq "npx codex-sdlc-wizard@$package_version setup --yes --model-profile mixed --goals" || valid=false
+
+    rm -rf "$ws" "$fakebin" "$codex_home"
+
+    if [ "$valid" = "true" ]; then
+        pass "optional Codex handoff failure warns after a successful artifact install"
+    else
+        fail "optional Codex handoff failure made a successful artifact install look failed"
+    fi
+}
+
+test_signal_terminated_optional_handoff_preserves_failure_status() {
+    if [ "$IS_WINDOWS" = "true" ]; then
+        pass "signal-terminated optional handoff status is POSIX-only"
+        return
+    fi
+
+    local ws fakebin codex_home input_file status valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
+    fakebin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-bin.XXXXXX")
+    codex_home=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-home.XXXXXX")
+    input_file="$ws/handoff-input.txt"
+
+    printf '%s' '{"name":"handoff-signal","scripts":{"test":"npm test"}}' > "$ws/package.json"
+    printf '\n' > "$input_file"
+
+    cat > "$fakebin/codex" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  echo "codex-cli 0.144.0"
+  exit 0
+fi
+kill -TERM "$$"
+EOF
+    chmod +x "$fakebin/codex"
+
+    set +e
+    (
+        cd "$ws" || exit 1
+        CODEX_HOME="$codex_home" \
+        CODEX_SDLC_CODEX_BIN="$fakebin/codex" \
+        CODEX_SDLC_DISABLE_REASONING=1 \
+        PATH="$fakebin:$PATH" \
+        node "$REPO_DIR/bin/codex-sdlc-wizard.js" < "$input_file" >/dev/null 2>&1
+    )
+    status=$?
+    set -e
+
+    [ "$status" -eq 143 ] || valid=false
+    [ -f "$ws/.codex/config.toml" ] || valid=false
+    [ -f "$ws/.agents/skills/sdlc/SKILL.md" ] || valid=false
+
+    rm -rf "$ws" "$fakebin" "$codex_home"
+
+    if [ "$valid" = "true" ]; then
+        pass "signal-terminated optional Codex handoff preserves failure status"
+    else
+        fail "signal-terminated optional Codex handoff was reported as success"
+    fi
+}
+
 test_unsupported_codex_version_blocks_handoff_before_mutation() {
     local ws fakebin codex_home output status valid=true
     ws=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
@@ -732,7 +837,7 @@ if [ "${1:-}" = "--version" ]; then
   exit 0
 fi
 printf started > "$FAKE_CODEX_STARTED_FILE"
-trap 'printf terminated > "$FAKE_CODEX_KILLED_FILE"; exit 143' TERM INT
+trap 'printf terminated > "$FAKE_CODEX_KILLED_FILE"; exit 0' TERM INT
 sleep 2
 printf completed > "$FAKE_CODEX_COMPLETED_FILE"
 exit 0
@@ -1368,6 +1473,8 @@ test_local_npx_setup_honors_model_profile_flag
 test_default_cli_updates_initialized_repo_without_explicit_subcommand
 test_packed_tarball_scratch_smoke
 test_default_interactive_hands_off_to_codex
+test_failed_optional_handoff_keeps_successful_install_successful
+test_signal_terminated_optional_handoff_preserves_failure_status
 test_unsupported_codex_version_blocks_handoff_before_mutation
 test_configured_codex_binary_drives_installer_version_gate
 test_interactive_handoff_preserves_goals_request

--- a/tests/test-roadmap.sh
+++ b/tests/test-roadmap.sh
@@ -66,7 +66,7 @@ test_roadmap_states_current_release_status() {
 test_roadmap_lists_next_release_cycle() {
     local has_semver_heading=true
     local has_heading=true
-    local has_pilot_rollout=true
+    local has_supported_surface_gate=true
     local has_stabilization_rule=true
     local next_release_section
     local next_release_heading
@@ -80,12 +80,12 @@ test_roadmap_lists_next_release_cycle() {
 
     grep -q '^## Next Release Cycle$' "$ROADMAP" || has_heading=false
     echo "$next_release_heading" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || has_semver_heading=false
-    echo "$next_release_section" | grep -Eqi 'pilot repos|pilot rollout|default use|default path' || has_pilot_rollout=false
-    echo "$next_release_section" | grep -Eqi 'reusable wizard bug|stabiliz|only if pilots surface' || has_stabilization_rule=false
+    echo "$next_release_section" | grep -Eqi 'supported-surface|Codex Desktop|ChatGPT Work|black-box' || has_supported_surface_gate=false
+    echo "$next_release_section" | grep -Eqi 'harden|reusable wizard bug|stabiliz|only if pilots surface' || has_stabilization_rule=false
 
     if [ "$has_heading" = "true" ] &&
        [ "$has_semver_heading" = "true" ] &&
-       [ "$has_pilot_rollout" = "true" ] &&
+       [ "$has_supported_surface_gate" = "true" ] &&
        [ "$has_stabilization_rule" = "true" ]; then
         pass "Roadmap lists the next release proof and main engineering item"
     else
@@ -93,10 +93,10 @@ test_roadmap_lists_next_release_cycle() {
     fi
 }
 
-test_roadmap_records_resolved_packaging_issue() {
+test_roadmap_records_stabilization_scope() {
     local has_heading=true
-    local has_resolved_packaging_issue=true
-    local has_no_active_stabilization_fix=true
+    local has_release_scope=true
+    local has_e2e_owner=true
     local has_new_issue_rule=true
     local avoids_active_issue_refs=true
     local cleanup_section
@@ -108,19 +108,19 @@ test_roadmap_records_resolved_packaging_issue() {
     ' "$ROADMAP")
 
     grep -q '^## Tracker Cleanup$' "$ROADMAP" || has_heading=false
-    echo "$cleanup_section" | grep -Eqi '#61.*(fixed|resolved|closed|released)|(fixed|resolved|closed|released).*#61' || has_resolved_packaging_issue=false
-    echo "$cleanup_section" | grep -Eqi 'no active (packaging|stabilization) fix|stabilization tracker.*clear' || has_no_active_stabilization_fix=false
+    echo "$cleanup_section" | grep -Eq '#55.*#56.*#69.*#70' || has_release_scope=false
+    echo "$cleanup_section" | grep -Eqi '#66.*(E2E|supported-surface)' || has_e2e_owner=false
     echo "$cleanup_section" | grep -Eqi 'open a new issue|pilot consumption exposes' || has_new_issue_rule=false
     echo "$cleanup_section" | grep -Eq '#15|#16|#17|#21|#22' && avoids_active_issue_refs=false
 
     if [ "$has_heading" = "true" ] &&
-       [ "$has_resolved_packaging_issue" = "true" ] &&
-       [ "$has_no_active_stabilization_fix" = "true" ] &&
+       [ "$has_release_scope" = "true" ] &&
+       [ "$has_e2e_owner" = "true" ] &&
        [ "$has_new_issue_rule" = "true" ] &&
        [ "$avoids_active_issue_refs" = "true" ]; then
-        pass "Roadmap records the resolved packaging fix and the rule for opening new issues from real consumption"
+        pass "Roadmap records the bounded stabilization scope and E2E owner"
     else
-        fail "Roadmap does not record the resolved packaging fix and clear stabilization state"
+        fail "Roadmap does not record the bounded stabilization scope and E2E owner"
     fi
 }
 
@@ -304,7 +304,7 @@ test_roadmap_prioritizes_plugin_surface_validation() {
 test_roadmap_exists
 test_roadmap_states_current_release_status
 test_roadmap_lists_next_release_cycle
-test_roadmap_records_resolved_packaging_issue
+test_roadmap_records_stabilization_scope
 test_roadmap_records_creator_investigation_outcome
 test_roadmap_tracks_goal_mode_guidance
 test_roadmap_tracks_official_codex_plugin_distribution_plan

--- a/tests/test-skill.sh
+++ b/tests/test-skill.sh
@@ -8,6 +8,7 @@ REPO_DIR="$SCRIPT_DIR/.."
 README="$REPO_DIR/README.md"
 SKILL_MD="$REPO_DIR/skills/codex-sdlc-wizard/SKILL.md"
 OPENAI_YAML="$REPO_DIR/skills/codex-sdlc-wizard/agents/openai.yaml"
+PLUGIN_MANIFEST="$REPO_DIR/.codex-plugin/plugin.json"
 REPO_SDLC_SKILL="$REPO_DIR/.agents/skills/sdlc/SKILL.md"
 REPO_ADLC_SKILL="$REPO_DIR/.agents/skills/adlc/SKILL.md"
 GLOBAL_SKILL_SOURCES="$REPO_DIR/skill-sources"
@@ -143,6 +144,39 @@ test_agents_openai_yaml_exists() {
         pass "agents/openai.yaml exists with Codex skill metadata"
     else
         fail "agents/openai.yaml is missing or incomplete"
+    fi
+}
+
+test_plugin_and_installer_skill_have_distinct_picker_intents() {
+    local plugin_default_prompt
+    local plugin_display_name
+    local plugin_short_description
+    local skill_default_prompt
+    local skill_display_name
+    local skill_short_description
+    local valid=true
+
+    plugin_default_prompt=$(node -e 'process.stdout.write(require(process.argv[1]).interface.defaultPrompt)' "$PLUGIN_MANIFEST")
+    plugin_display_name=$(node -e 'process.stdout.write(require(process.argv[1]).interface.displayName)' "$PLUGIN_MANIFEST")
+    plugin_short_description=$(node -e 'process.stdout.write(require(process.argv[1]).interface.shortDescription)' "$PLUGIN_MANIFEST")
+    skill_default_prompt=$(sed -n 's/^  default_prompt: "\(.*\)"$/\1/p' "$OPENAI_YAML")
+    skill_display_name=$(sed -n 's/^  display_name: "\(.*\)"$/\1/p' "$OPENAI_YAML")
+    skill_short_description=$(sed -n 's/^  short_description: "\(.*\)"$/\1/p' "$OPENAI_YAML")
+
+    [ "$plugin_display_name" = "Codex SDLC Wizard" ] || valid=false
+    [ "$plugin_short_description" = "Explore Codex SDLC workflows" ] || valid=false
+    [ "$plugin_default_prompt" = "Show me the Codex SDLC Wizard workflows available for this repository and help me choose the right one." ] || valid=false
+    [ "$skill_display_name" = "Install SDLC Guardrails" ] || valid=false
+    [ "$skill_short_description" = "Set up or repair repo SDLC" ] || valid=false
+    [ "$skill_default_prompt" = "Use \$codex-sdlc-wizard to install or update Codex SDLC enforcement in this repository." ] || valid=false
+    [ "$plugin_display_name" != "$skill_display_name" ] || valid=false
+    [ "$plugin_short_description" != "$skill_short_description" ] || valid=false
+    [ "$plugin_default_prompt" != "$skill_default_prompt" ] || valid=false
+
+    if [ "$valid" = "true" ]; then
+        pass "Plugin and bundled installer skill have distinct picker intents"
+    else
+        fail "Plugin and bundled installer skill are ambiguous in the picker"
     fi
 }
 
@@ -415,6 +449,7 @@ test_plugin_skill_resolves_bundled_scripts_from_plugin_root
 test_plugin_skill_handles_legacy_standalone_install
 test_plugin_skill_documents_surface_specific_installation
 test_agents_openai_yaml_exists
+test_plugin_and_installer_skill_have_distinct_picker_intents
 test_readme_documents_dual_distribution
 test_readme_recommends_current_codex_startup
 test_skill_recommends_current_codex_after_install

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -573,6 +573,181 @@ NODE
     fi
 }
 
+test_update_repairs_managed_hook_drift_without_overwriting_host_hooks() {
+    local ws output precheck_output check_output host_hook_command host_hook_with_wizard_argument wizard_drift_command valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    echo '{"name":"test-app","scripts":{"test":"jest"}}' > "$ws/package.json"
+    mkdir -p "$ws/src"
+
+    if [ "$IS_WINDOWS" = "true" ]; then
+        host_hook_command="bash .custom/bash-guard.sh"
+        host_hook_with_wizard_argument="node .custom/audit.cjs .codex/hooks/bash-guard.sh"
+        wizard_drift_command='bash .codex\hooks\bash-guard.sh'
+    else
+        host_hook_command="powershell.exe -File .custom/host.ps1"
+        host_hook_with_wizard_argument="node .custom/audit.cjs .codex/hooks/git-guard.ps1"
+        wizard_drift_command='powershell.exe -File .codex\hooks\git-guard.ps1'
+    fi
+
+    run_setup_local "$ws"
+    HOOKS_JSON_PATH="$ws/.codex/hooks.json" HOST_HOOK_COMMAND="$host_hook_command" HOST_HOOK_WITH_WIZARD_ARGUMENT="$host_hook_with_wizard_argument" WIZARD_DRIFT_COMMAND="$wizard_drift_command" node <<'NODE'
+const fs = require("fs");
+const hooksPath = process.env.HOOKS_JSON_PATH;
+const data = JSON.parse(fs.readFileSync(hooksPath, "utf8"));
+data.customSetting = "keep-me";
+data.hooks.PreToolUse.push({
+  matcher: "^Write$",
+  hooks: [{ type: "command", command: "node .custom/guard.cjs" }],
+});
+data.hooks.PreToolUse[0].hooks[0].command = process.env.WIZARD_DRIFT_COMMAND;
+data.hooks.PostToolUse = [{
+  hooks: [
+    { type: "command", command: process.env.HOST_HOOK_COMMAND },
+    { type: "command", command: process.env.HOST_HOOK_WITH_WIZARD_ARGUMENT },
+  ],
+}];
+fs.writeFileSync(hooksPath, `${JSON.stringify(data, null, 2)}\n`);
+NODE
+
+    precheck_output=$(run_check "$ws")
+    output=$(run_update "$ws" 2>&1) || valid=false
+    check_output=$(run_check "$ws")
+
+    HOOKS_PATH="$ws/.codex/hooks.json" HOST_HOOK_COMMAND="$host_hook_command" HOST_HOOK_WITH_WIZARD_ARGUMENT="$host_hook_with_wizard_argument" node <<'NODE' || valid=false
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(process.env.HOOKS_PATH, "utf8"));
+const commands = Object.values(data.hooks || {}).flatMap((entries) =>
+  entries.flatMap((entry) => (entry.hooks || []).map((hook) => hook.command))
+);
+if (data.customSetting !== "keep-me") process.exit(1);
+if (!commands.includes("node .custom/guard.cjs")) process.exit(1);
+if (!commands.includes(process.env.HOST_HOOK_COMMAND)) process.exit(1);
+if (!commands.includes(process.env.HOST_HOOK_WITH_WIZARD_ARGUMENT)) process.exit(1);
+if (commands.includes(".codex/hooks/bash-guard.sh")) process.exit(1);
+if (commands.filter((command) => command === "node .codex/hooks/git-guard.cjs").length !== 1) process.exit(1);
+NODE
+    json_text_equals "$precheck_output" 'data.managed_files[".codex/hooks.json"].status' "drift / broken" || valid=false
+    json_text_equals "$check_output" 'data.managed_files[".codex/hooks.json"].status' "match" || valid=false
+    rm -rf "$ws"
+
+    if [ "$valid" = "true" ]; then
+        pass "update repairs wizard hook drift while preserving host hooks"
+    else
+        echo "$output" >&2
+        fail "update overwrote host hooks while repairing wizard hook drift"
+    fi
+}
+
+test_update_merges_hook_config_without_overwriting_customized_hook_scripts() {
+    local ws output check_output script_before valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    echo '{"name":"test-app","scripts":{"test":"jest"}}' > "$ws/package.json"
+    mkdir -p "$ws/src"
+
+    run_setup_local "$ws"
+    printf '%s\n' '// USER CUSTOM GUARD' > "$ws/.codex/hooks/git-guard.cjs"
+    script_before=$(cat "$ws/.codex/hooks/git-guard.cjs")
+    HOOKS_JSON_PATH="$ws/.codex/hooks.json" node <<'NODE'
+const fs = require("fs");
+const hooksPath = process.env.HOOKS_JSON_PATH;
+const data = JSON.parse(fs.readFileSync(hooksPath, "utf8"));
+data.hooks.PreToolUse[0].hooks[0].command = ".codex/hooks/bash-guard.sh";
+fs.writeFileSync(hooksPath, `${JSON.stringify(data, null, 2)}\n`);
+NODE
+
+    output=$(run_update "$ws" 2>&1) || valid=false
+    check_output=$(run_check "$ws")
+
+    [ "$(cat "$ws/.codex/hooks/git-guard.cjs")" = "$script_before" ] || valid=false
+    echo "$output" | grep -Fq '.codex/hooks/git-guard.cjs: customized -> skip (preserve customization)' || valid=false
+    HOOKS_PATH="$ws/.codex/hooks.json" node <<'NODE' || valid=false
+const fs = require("fs");
+const data = JSON.parse(fs.readFileSync(process.env.HOOKS_PATH, "utf8"));
+const commands = Object.values(data.hooks || {}).flatMap((entries) =>
+  entries.flatMap((entry) => (entry.hooks || []).map((hook) => hook.command))
+);
+if (commands.some((command) => /bash-guard/.test(command))) process.exit(1);
+if (commands.filter((command) => command === "node .codex/hooks/git-guard.cjs").length !== 1) process.exit(1);
+NODE
+    json_text_equals "$check_output" 'data.managed_files[".codex/hooks.json"].status' "match" || valid=false
+    json_text_equals "$check_output" 'data.managed_files[".codex/hooks/git-guard.cjs"].status' "customized" || valid=false
+    rm -rf "$ws"
+
+    if [ "$valid" = "true" ]; then
+        pass "update merges hook config without overwriting customized hook scripts"
+    else
+        echo "$output" >&2
+        fail "update overwrote a customized hook script while merging hooks.json"
+    fi
+}
+
+test_check_treats_bom_prefixed_hooks_as_customized() {
+    local ws check_output valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    echo '{"name":"test-app","scripts":{"test":"jest"}}' > "$ws/package.json"
+    mkdir -p "$ws/src"
+
+    run_setup_local "$ws"
+    HOOKS_PATH="$ws/.codex/hooks.json" node <<'NODE'
+const fs = require("fs");
+const hooksPath = process.env.HOOKS_PATH;
+fs.writeFileSync(hooksPath, `\uFEFF${fs.readFileSync(hooksPath, "utf8")}`);
+NODE
+    check_output=$(run_check "$ws") || valid=false
+    json_text_equals "$check_output" 'data.managed_files[".codex/hooks.json"].status' "customized" || valid=false
+    rm -rf "$ws"
+
+    if [ "$valid" = "true" ]; then
+        pass "check parses BOM-prefixed hooks.json before classifying drift"
+    else
+        fail "check treated a BOM-prefixed hooks.json as broken"
+    fi
+}
+
+test_update_replaces_and_backs_up_malformed_hooks() {
+    local ws output check_output backup_path valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    echo '{"name":"test-app","scripts":{"test":"jest"}}' > "$ws/package.json"
+    mkdir -p "$ws/src"
+
+    run_setup_local "$ws"
+    printf '%s\n' 'legacy git guard' > "$ws/.codex/hooks/git-guard.js"
+    printf '%s\n' 'legacy session hook' > "$ws/.codex/hooks/session-start.js"
+    MANIFEST_PATH="$ws/.codex-sdlc/manifest.json" node <<'NODE'
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const manifestPath = process.env.MANIFEST_PATH;
+const root = path.dirname(path.dirname(manifestPath));
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+for (const relativePath of [".codex/hooks/git-guard.js", ".codex/hooks/session-start.js"]) {
+  const content = fs.readFileSync(path.join(root, relativePath));
+  manifest.managed_files[relativePath] = `sha256:${crypto.createHash("sha256").update(content).digest("hex")}`;
+}
+fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+    printf '%s\n' '{ malformed hooks json' > "$ws/.codex/hooks.json"
+
+    output=$(run_update "$ws" 2>&1) || valid=false
+    check_output=$(run_check "$ws") || valid=false
+    backup_path=$(find "$ws/.codex" -maxdepth 1 -name 'hooks.json.bak.*' -print -quit)
+
+    [ -n "$backup_path" ] || valid=false
+    [ "$(cat "$backup_path")" = '{ malformed hooks json' ] || valid=false
+    [ ! -e "$ws/.codex/hooks/git-guard.js" ] || valid=false
+    [ ! -e "$ws/.codex/hooks/session-start.js" ] || valid=false
+    json_text_equals "$check_output" 'data.managed_files[".codex/hooks.json"].status' "match" || valid=false
+    echo "$output" | grep -Fq 'replace broken hooks (backup original)' || valid=false
+    rm -rf "$ws"
+
+    if [ "$valid" = "true" ]; then
+        pass "update backs up and replaces malformed hooks.json"
+    else
+        echo "$output" >&2
+        fail "update could not recover a malformed hooks.json"
+    fi
+}
+
 # ---- Test 12: update merges managed hook config into existing config.toml ----
 test_update_merges_config_without_dropping_other_settings() {
     local ws
@@ -1354,6 +1529,10 @@ test_update_repairs_legacy_js_hook_manifest_entries
 test_update_repairs_matching_legacy_js_hook_manifest_entries
 test_update_repairs_matching_hook_surface_without_compact_lifecycle
 test_update_repairs_missing_compact_guard_without_overwriting_custom_hooks
+test_update_repairs_managed_hook_drift_without_overwriting_host_hooks
+test_update_merges_hook_config_without_overwriting_customized_hook_scripts
+test_check_treats_bom_prefixed_hooks_as_customized
+test_update_replaces_and_backs_up_malformed_hooks
 test_update_merges_config_without_dropping_other_settings
 test_update_repairs_missing_native_skills
 test_update_removes_legacy_codex_sdlc_skill

--- a/update.sh
+++ b/update.sh
@@ -34,6 +34,7 @@ LEGACY_MODEL_POLICY_SDLC_SKILL_HASH="sha256:c2c280c2b0edf97538c674bf131eec06f0b6
 LEGACY_FEEDBACK_SKILL_HASH="sha256:cdda0e9e12b764154a44c91f8de352138d85ce18f491972099fd332301b98ca1"
 LEGACY_SETUP_WIZARD_SKILL_HASH="sha256:9e32cf8acb99ad5876e86e561f846e5b2542f12c26b85d08566a38589ee6ccc7"
 LEGACY_UPDATE_WIZARD_SKILL_HASH="sha256:82696ee709eafdeef3f35def96c9179c485b368d300148326b49560d35262aad"
+HOOKS_BACKUP_PATH=""
 
 for arg in "$@"; do
     case "$arg" in
@@ -82,6 +83,19 @@ copy_static_file() {
     esac
 }
 
+repair_hooks_config() {
+    if [ "$HOOKS_MERGE_STATUS" = "target-broken" ]; then
+        if [ -z "$HOOKS_BACKUP_PATH" ]; then
+            HOOKS_BACKUP_PATH=".codex/hooks.json.bak.$(date +%Y%m%d%H%M%S).$$"
+            cp ".codex/hooks.json" "$HOOKS_BACKUP_PATH"
+        fi
+        cp "$HOOKS_TEMPLATE" ".codex/hooks.json"
+        HOOKS_MERGE_STATUS="match"
+    else
+        node "$SCRIPT_DIR/lib/merge-hooks.cjs" ".codex/hooks.json" "$HOOKS_TEMPLATE"
+    fi
+}
+
 repair_hooks_bundle() {
     ensure_parent_dir ".codex/hooks.json"
     ensure_parent_dir ".codex/hooks/dummy"
@@ -91,21 +105,42 @@ repair_hooks_bundle() {
     rm -f .codex/hooks/git-guard.js .codex/hooks/session-start.js
 
     if [ "$IS_WINDOWS" = "true" ]; then
-        copy_static_file ".codex/windows-hooks.json" ".codex/hooks.json"
         copy_static_file ".codex/hooks/git-guard.ps1"
         copy_static_file ".codex/hooks/session-start.ps1"
     else
-        copy_static_file ".codex/unix-hooks.json" ".codex/hooks.json"
         copy_static_file ".codex/hooks/bash-guard.sh"
         copy_static_file ".codex/hooks/session-start.sh"
     fi
+    repair_hooks_config
+}
+
+repair_missing_hook_scripts() {
+    local required_hooks required_hook
+    required_hooks=".codex/hooks/git-guard.cjs .codex/hooks/session-start.cjs .codex/hooks/compact-guard.cjs"
+    if [ "$IS_WINDOWS" = "true" ]; then
+        required_hooks="$required_hooks .codex/hooks/git-guard.ps1 .codex/hooks/session-start.ps1"
+    else
+        required_hooks="$required_hooks .codex/hooks/bash-guard.sh .codex/hooks/session-start.sh"
+    fi
+
+    for required_hook in $required_hooks; do
+        if [ ! -f "$required_hook" ]; then
+            copy_static_file "$required_hook"
+        fi
+    done
 }
 
 repair_managed_file() {
     local relative_path="$1"
 
     case "$relative_path" in
-        .codex/hooks.json|.codex/hooks/git-guard.js|.codex/hooks/session-start.js)
+        .codex/hooks.json)
+            ensure_parent_dir ".codex/hooks.json"
+            repair_hooks_config
+            repair_missing_hook_scripts
+            rm -f .codex/hooks/git-guard.js .codex/hooks/session-start.js
+            ;;
+        .codex/hooks/git-guard.js|.codex/hooks/session-start.js)
             repair_hooks_bundle
             ;;
         .codex/config.toml)
@@ -371,6 +406,15 @@ if [ "$REPO_STATE" != "initialized" ]; then
     exit 1
 fi
 
+if [ "$IS_WINDOWS" = "true" ]; then
+    HOOKS_TEMPLATE="$SCRIPT_DIR/.codex/windows-hooks.json"
+else
+    HOOKS_TEMPLATE="$SCRIPT_DIR/.codex/unix-hooks.json"
+fi
+HOOKS_MERGE_STATUS="$(
+    node "$SCRIPT_DIR/lib/merge-hooks.cjs" --status ".codex/hooks.json" "$HOOKS_TEMPLATE"
+)"
+
 STATUS_LINES=()
 while IFS= read -r status_line; do
     STATUS_LINES+=("$status_line")
@@ -451,7 +495,22 @@ for line in "${STATUS_LINES[@]}"; do
     [ -n "$relative_path" ] || continue
 
     action="keep"
-    case "$status" in
+    if [ "$relative_path" = ".codex/hooks.json" ]; then
+        if [ "$HOOKS_MERGE_STATUS" = "merge" ]; then
+            action="merge wizard hooks (preserve host hooks)"
+            CHANGES_PENDING=true
+            RUN_REGENERATE=true
+            queue_static_repair "$relative_path"
+        elif [ "$HOOKS_MERGE_STATUS" = "target-broken" ]; then
+            action="replace broken hooks (backup original)"
+            CHANGES_PENDING=true
+            RUN_REGENERATE=true
+            queue_static_repair "$relative_path"
+        fi
+    fi
+
+    if [ "$action" = "keep" ]; then
+      case "$status" in
         match)
             if [ "$relative_path" = ".codex-sdlc/model-profile.json" ] && [ "$MODEL_PROFILE_MIGRATION" = "true" ]; then
                 action="refresh legacy model profile metadata"
@@ -511,7 +570,8 @@ for line in "${STATUS_LINES[@]}"; do
         *)
             action="inspect"
             ;;
-    esac
+      esac
+    fi
 
     PLAN_LINES+=("$relative_path|$status|$action")
 done


### PR DESCRIPTION
## Summary

- preserve host hooks while merging wizard-owned Codex hooks
- keep successful installation successful when optional Codex handoff fails
- refresh only installer-touched manifest hashes and preserve customizations
- remove duplicate picker identities and clarify install/repair intent
- harden Windows Git Bash path handling, structural hook validation, atomic permissions, and version-pinned recovery

## Validation

- full 11-group proof suite passed
- native Codex Sol High review passed
- independent Fable High review passed
- Claude-driven black-box Codex Desktop and ChatGPT Work E2E passed

Closes #55.
Closes #56.
Progresses #66 and #69.