### PR TITLE
fix: clarify first-run setup and retire stale hook

### DIFF
--- a/.codex/hooks/sdlc-prompt-check.sh
+++ b/.codex/hooks/sdlc-prompt-check.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-cat << 'EOF'
-SDLC BASELINE:
-1. Plan before coding — state confidence level
-2. TDD: Write failing test FIRST, then implement
-3. ALL tests must pass before commit
-4. Self-review before presenting to user
-EOF

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ A **self-evolving Software Development Life Cycle (SDLC) enforcement system for 
 
 This adapter brings the [SDLC Wizard](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard) discipline into Codex projects with Codex-native skills, `.codex/` hooks, `AGENTS.md`, adaptive setup/update, and proof-aware git gates.
 
+## Which entry point should I use?
+
+Think of the plugin, installer skill, and repo skill as three consecutive layers:
+
+| What you are doing | Use | How often |
+|---|---|---|
+| Install or enable the package | **Codex SDLC Wizard** in the Desktop Plugins Directory, or `/plugins` in Codex CLI | Once per supported surface |
+| Set up or repair the current repository | `$codex-sdlc-wizard` with the target repo selected | Once per repo, then whenever setup needs repair |
+| Plan, implement, test, and review normal repo work | `$sdlc` | Every meaningful delivery task after setup |
+| Pull the newest npm release and update repo artifacts before the public listing is available | `npx codex-sdlc-wizard@latest update` | When you intentionally want the newest published package |
+
+The plugin is the installable container; `$` opens the skill picker, so it should show the plugin's **Install SDLC Guardrails** skill rather than a second plugin row. After setup, restart or reopen Codex in the repository before invoking `$sdlc` so the repo-local config, hooks, docs, and skill are loaded.
+
+Use the default `maximum` profile for normal work: GPT-5.6 Sol at `high`. The `mixed` profile is an experimental explicit opt-in using Terra at `medium` with a Sol `high` review. Luna is currently a bounded support option, not an install-time profile.
+
+These workflows work in Codex Desktop, Codex CLI, and ChatGPT Work when the active project can access the repository and a shell. Ordinary Chat can display the installed plugin in its directory but cannot invoke repo-local skills; switch to Work or Codex for installation and delivery work.
+
 ## Quick Start
 
 ```bash

--- a/install.ps1
+++ b/install.ps1
@@ -58,17 +58,47 @@ function Install-AgentsBaseline {
         [string]$Profile
     )
 
-    if (Test-Path -LiteralPath "AGENTS.md") {
-        Write-Host "AGENTS.md already exists - skipping (review manually)"
-        return
-    }
-
     $reasoningBaseline = if ($Profile -eq "mixed") { "medium" } else { "high" }
     $content = Get-Content -LiteralPath $Source -Raw
     $content = $content.Replace("{{MODEL_PROFILE}}", $Profile).Replace("{{REASONING_BASELINE}}", $reasoningBaseline)
+
+    if (Test-Path -LiteralPath "AGENTS.md") {
+        if ($env:CODEX_SDLC_SETUP_GENERATED_AGENTS -eq "true") {
+            Write-Host "AGENTS.md generated earlier in this setup - keeping it"
+        } elseif ((Get-Content -LiteralPath "AGENTS.md" -Raw) -ceq $content) {
+            Write-Host "AGENTS.md already matches the wizard baseline - keeping it"
+        } elseif (Test-AgentsManifestMatch -Path "AGENTS.md") {
+            Write-Host "AGENTS.md is wizard-managed - keeping it; profile guidance will be refreshed if needed"
+        } else {
+            Write-Host "AGENTS.md is user-owned or customized - preserving it"
+        }
+        return
+    }
+
     Set-Content -LiteralPath "AGENTS.md" -Value $content -NoNewline
     Add-TouchedFile -Path "AGENTS.md"
     Write-Host "Created AGENTS.md"
+}
+
+function Test-AgentsManifestMatch {
+    param([string]$Path)
+
+    $manifestPath = ".codex-sdlc\manifest.json"
+    if (-not (Test-Path -LiteralPath $manifestPath)) {
+        return $false
+    }
+
+    try {
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+        $expected = $manifest.managed_files.$Path
+        if (-not $expected) {
+            return $false
+        }
+        $actual = "sha256:" + (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+        return $actual -eq $expected
+    } catch {
+        return $false
+    }
 }
 
 function Copy-IfMissing {
@@ -429,6 +459,10 @@ Install-RepoSkill -SourceRoot $scriptDir -Name "sdlc"
 
 New-Item -ItemType Directory -Path ".codex" -Force | Out-Null
 New-Item -ItemType Directory -Path ".codex\hooks" -Force | Out-Null
+& node (Join-Path $scriptDir "lib\remove-retired-files.cjs")
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to inspect retired wizard files"
+}
 
 $configPath = ".codex\config.toml"
 Merge-CodexModelConfig -ConfigPath $configPath -Profile $ModelProfile

--- a/install.sh
+++ b/install.sh
@@ -80,13 +80,13 @@ for required in \
   ".codex/windows-hooks.json" \
   ".codex/hooks/bash-guard.sh" \
   ".codex/hooks/session-start.sh" \
-  ".codex/hooks/sdlc-prompt-check.sh" \
   ".codex/hooks/git-guard.cjs" \
   ".codex/hooks/session-start.cjs" \
   ".codex/hooks/compact-guard.cjs" \
   ".codex/hooks/git-guard.ps1" \
   ".codex/hooks/session-start.ps1" \
   "lib/merge-hooks.cjs" \
+  "lib/remove-retired-files.cjs" \
   "lib/refresh-manifest-hashes.cjs" \
   ".agents/skills/sdlc/SKILL.md"; do
   require_bundle_file "$SCRIPT_DIR/$required" "$required"
@@ -236,12 +236,38 @@ install_agents_baseline() {
   local target="AGENTS.md"
   local reasoning_baseline
 
+  reasoning_baseline="$(profile_reasoning "$MODEL_PROFILE")"
+
   if [ -f "$target" ]; then
-    echo "AGENTS.md already exists - skipping (review manually)"
+    if [ "${CODEX_SDLC_SETUP_GENERATED_AGENTS:-false}" = "true" ]; then
+      echo "AGENTS.md generated earlier in this setup - keeping it"
+    elif cmp -s "$target" <(sed \
+      -e "s|{{MODEL_PROFILE}}|$MODEL_PROFILE|g" \
+      -e "s|{{REASONING_BASELINE}}|$reasoning_baseline|g" \
+      "$source"); then
+      echo "AGENTS.md already matches the wizard baseline - keeping it"
+    elif [ -f ".codex-sdlc/manifest.json" ] && \
+      AGENTS_TARGET="$target" node - <<'NODE'
+const crypto = require("crypto");
+const fs = require("fs");
+
+try {
+  const manifest = JSON.parse(fs.readFileSync(".codex-sdlc/manifest.json", "utf8"));
+  const expected = manifest.managed_files?.[process.env.AGENTS_TARGET];
+  const actual = `sha256:${crypto.createHash("sha256").update(fs.readFileSync(process.env.AGENTS_TARGET)).digest("hex")}`;
+  process.exit(expected === actual ? 0 : 1);
+} catch {
+  process.exit(1);
+}
+NODE
+    then
+      echo "AGENTS.md is wizard-managed - keeping it; profile guidance will be refreshed if needed"
+    else
+      echo "AGENTS.md is user-owned or customized - preserving it"
+    fi
     return 0
   fi
 
-  reasoning_baseline="$(profile_reasoning "$MODEL_PROFILE")"
   sed \
     -e "s|{{MODEL_PROFILE}}|$MODEL_PROFILE|g" \
     -e "s|{{REASONING_BASELINE}}|$reasoning_baseline|g" \
@@ -276,6 +302,7 @@ remove_wizard_managed_global_skill "sdlc" "repo-scoped .agents/skills/sdlc is th
 prune_legacy_global_skill "codex-sdlc" "sdlc"
 
 mkdir -p .codex/hooks
+node "$SCRIPT_DIR/lib/remove-retired-files.cjs"
 
 merge_codex_config_profile ".codex/config.toml" "$MODEL_PROFILE"
 mark_install_touched ".codex/config.toml"

--- a/lib/remove-retired-files.cjs
+++ b/lib/remove-retired-files.cjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { directoryFoldsCase } = require("./merge-hooks.cjs");
+
+const checkOnly = process.argv.includes("--status");
+const manifestPath = ".codex-sdlc/manifest.json";
+const retiredFiles = [
+  {
+    path: ".codex/hooks/sdlc-prompt-check.sh",
+    hashes: new Set([
+      "84ba0abfdf7b55849dd925a726c5de77d713d83efd9c50b19dfa06ff38f28112",
+      "0e395ce56dae7c017cd761eb669cb9302f251abe8493b35f34c5e00effc50258",
+    ]),
+  },
+];
+
+function inspectRetiredFile(entry) {
+  let stat;
+  try {
+    stat = fs.lstatSync(entry.path);
+  } catch (error) {
+    if (error.code === "ENOENT") return "missing";
+    throw error;
+  }
+
+  if (stat.isSymbolicLink()) {
+    try {
+      fs.statSync(entry.path);
+    } catch (error) {
+      if (error.code === "ENOENT") return "missing";
+      throw error;
+    }
+    return "customized";
+  }
+  if (!stat.isFile()) return "customized";
+  const hash = crypto.createHash("sha256").update(fs.readFileSync(entry.path)).digest("hex");
+  return entry.hashes.has(hash) ? "wizard-managed" : "customized";
+}
+
+function commandTokens(command, foldPathCase) {
+  const tokens = command.match(/"[^"\r\n]*"|'[^'\r\n]*'|`[^`\r\n]*`|[^\s]+/g) || [];
+  return tokens.map((token) => {
+    const first = token[0];
+    const unquoted = token.length >= 2
+      && (first === '"' || first === "'" || first === "`")
+      && token.at(-1) === first
+      ? token.slice(1, -1)
+      : token;
+    const normalized = unquoted.replaceAll("\\", "/");
+    return foldPathCase ? normalized.toLowerCase() : normalized;
+  });
+}
+
+function isStandardWizardInvocation(tokens, normalizedPath) {
+  const isRetiredPath = (token) => token === normalizedPath || token === `./${normalizedPath}`;
+  if (isRetiredPath(tokens[0])) return true;
+
+  const executable = (tokens[0] || "").split("/").at(-1).toLowerCase();
+  return /^(?:bash|sh)$/.test(executable) && isRetiredPath(tokens[1]);
+}
+
+function hasRetainedHookReference(retiredPath) {
+  const hooksPath = ".codex/hooks.json";
+  if (!fs.existsSync(hooksPath)) return false;
+
+  let hooks;
+  try {
+    hooks = JSON.parse(fs.readFileSync(hooksPath, "utf8").replace(/^\uFEFF/, ""));
+  } catch (_error) {
+    return false;
+  }
+
+  const commands = [];
+  const visit = (value) => {
+    if (!value || typeof value !== "object") return;
+    if (typeof value.command === "string") commands.push(value.command);
+    for (const child of Object.values(value)) visit(child);
+  };
+  visit(hooks);
+
+  const foldPathCase = directoryFoldsCase(path.dirname(hooksPath));
+  const pathNormalized = retiredPath.replaceAll("\\", "/");
+  const normalizedPath = foldPathCase ? pathNormalized.toLowerCase() : pathNormalized;
+  const retiredScriptName = path.posix.basename(pathNormalized).toLowerCase();
+  return commands.some((command) => {
+    const tokens = commandTokens(command, foldPathCase);
+    const referencesPath = tokens.some((token) => token.toLowerCase().includes(retiredScriptName));
+    return referencesPath && !isStandardWizardInvocation(tokens, normalizedPath);
+  });
+}
+
+function readManifest() {
+  if (!fs.existsSync(manifestPath)) return null;
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error(`${manifestPath} must contain a JSON object`);
+  }
+  if (!manifest.managed_files || typeof manifest.managed_files !== "object" || Array.isArray(manifest.managed_files)) {
+    throw new Error(`${manifestPath}.managed_files must contain a JSON object`);
+  }
+  return manifest;
+}
+
+function writeManifest(manifest) {
+  const temporary = path.join(
+    path.dirname(manifestPath),
+    `.${path.basename(manifestPath)}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  const mode = fs.statSync(manifestPath).mode & 0o777;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { flag: "wx", mode });
+    fs.chmodSync(temporary, mode);
+    fs.renameSync(temporary, manifestPath);
+  } finally {
+    try {
+      fs.unlinkSync(temporary);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+const manifest = readManifest();
+
+for (const entry of retiredFiles) {
+  const fileStatus = inspectRetiredFile(entry);
+  const retainedHookReference = hasRetainedHookReference(entry.path);
+  const manifestTracked = Boolean(
+    manifest && Object.prototype.hasOwnProperty.call(manifest.managed_files, entry.path),
+  );
+  const status = retainedHookReference
+    ? fileStatus === "missing"
+      ? "retained-missing"
+      : manifestTracked
+        ? "tracked-retired"
+        : "retained-customized"
+    : fileStatus === "wizard-managed"
+      ? "wizard-managed"
+      : manifestTracked
+        ? "tracked-retired"
+        : fileStatus;
+  if (checkOnly) {
+    process.stdout.write(`${entry.path}\t${status}\n`);
+    continue;
+  }
+
+  if (retainedHookReference && fileStatus === "missing") {
+    throw new Error(`Retained hook references missing retired file: ${entry.path}`);
+  } else if (fileStatus === "wizard-managed" && !retainedHookReference) {
+    fs.unlinkSync(entry.path);
+    process.stdout.write(`Removed retired wizard file: ${entry.path}\n`);
+  } else if (retainedHookReference) {
+    process.stdout.write(`Preserved retired file still referenced by a retained hook: ${entry.path}\n`);
+  } else if (fileStatus === "customized") {
+    process.stdout.write(`Preserved customized retired file: ${entry.path}\n`);
+  }
+  if (manifestTracked) {
+    delete manifest.managed_files[entry.path];
+    writeManifest(manifest);
+    process.stdout.write(`Removed retired manifest ownership: ${entry.path}\n`);
+  }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1125,6 +1125,7 @@ substitute_template() {
 }
 
 # Generate AGENTS.md
+SETUP_GENERATED_AGENTS=false
 generate_file() {
     local target="$1"
     local template="$2"
@@ -1140,6 +1141,9 @@ generate_file() {
         return
     fi
     substitute_template "$template" > "$target"
+    if [ "$target" = "AGENTS.md" ]; then
+        SETUP_GENERATED_AGENTS=true
+    fi
     echo "Generated $label"
 }
 
@@ -1175,7 +1179,8 @@ generate_testing_md
 # ---- Step 4: Run install.sh (hooks + config) ----
 if [ "$SETUP_MODE" != "regenerate" ]; then
     echo ""
-    bash "$SCRIPT_DIR/install.sh" --model-profile "$MODEL_PROFILE"
+    CODEX_SDLC_SETUP_GENERATED_AGENTS="$SETUP_GENERATED_AGENTS" \
+        bash "$SCRIPT_DIR/install.sh" --model-profile "$MODEL_PROFILE"
 fi
 
 # ---- Step 5: Write manifest ----

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -1659,17 +1659,94 @@ test_config_enables_hooks() {
 }
 
 test_install_preserves_agents_md() {
-    local tmpdir
+    local tmpdir output
     tmpdir=$(mktemp -d)
     echo "CUSTOM AGENTS CONTENT" > "$tmpdir/AGENTS.md"
-    (cd "$tmpdir" && CODEX_HOME="$tmpdir/.codex-home" bash "$REPO_DIR/install.sh" >/dev/null 2>&1)
+    output=$(cd "$tmpdir" && CODEX_HOME="$tmpdir/.codex-home" bash "$REPO_DIR/install.sh" 2>&1)
     local content
     content=$(cat "$tmpdir/AGENTS.md")
     rm -rf "$tmpdir"
-    if [ "$content" = "CUSTOM AGENTS CONTENT" ]; then
-        pass "install.sh preserves existing AGENTS.md"
+    if [ "$content" = "CUSTOM AGENTS CONTENT" ] \
+        && echo "$output" | grep -Fq 'AGENTS.md is user-owned or customized - preserving it' \
+        && ! echo "$output" | grep -Fq 'AGENTS.md already exists - skipping (review manually)'; then
+        pass "install.sh preserves and accurately reports customized AGENTS.md"
     else
-        fail "install.sh overwrote existing AGENTS.md"
+        fail "install.sh overwrote or ambiguously reported customized AGENTS.md"
+    fi
+}
+
+test_install_reports_current_agents_baseline() {
+    local tmpdir output
+    tmpdir=$(mktemp -d)
+    sed \
+        -e 's|{{MODEL_PROFILE}}|maximum|g' \
+        -e 's|{{REASONING_BASELINE}}|high|g' \
+        "$REPO_DIR/templates/AGENTS.baseline.md" > "$tmpdir/AGENTS.md"
+
+    output=$(cd "$tmpdir" && CODEX_HOME="$tmpdir/.codex-home" bash "$REPO_DIR/install.sh" 2>&1)
+    rm -rf "$tmpdir"
+
+    if echo "$output" | grep -Fq 'AGENTS.md already matches the wizard baseline - keeping it' \
+        && ! echo "$output" | grep -Fq 'AGENTS.md already exists - skipping (review manually)'; then
+        pass "install.sh distinguishes an already-current AGENTS.md baseline"
+    else
+        fail "install.sh did not identify an already-current AGENTS.md baseline"
+    fi
+}
+
+test_install_omits_inactive_prompt_hook() {
+    local tmpdir custom_tmpdir
+    tmpdir=$(mktemp -d)
+    custom_tmpdir=$(mktemp -d)
+    mkdir -p "$tmpdir/.codex/hooks" "$custom_tmpdir/.codex/hooks"
+    for target in "$tmpdir/.codex/hooks/sdlc-prompt-check.sh" "$custom_tmpdir/.codex/hooks/sdlc-prompt-check.sh"; do
+        printf '%s\n' \
+            '#!/bin/bash' \
+            "cat << 'EOF'" \
+            'SDLC BASELINE:' \
+            '1. Plan before coding — state confidence level' \
+            '2. TDD: Write failing test FIRST, then implement' \
+            '3. ALL tests must pass before commit' \
+            '4. Self-review before presenting to user' \
+            'EOF' > "$target"
+    done
+    printf '%s\n' '# user customization' >> "$custom_tmpdir/.codex/hooks/sdlc-prompt-check.sh"
+
+    (cd "$tmpdir" && CODEX_HOME="$tmpdir/.codex-home" bash "$REPO_DIR/install.sh" >/dev/null 2>&1)
+    (cd "$custom_tmpdir" && CODEX_HOME="$custom_tmpdir/.codex-home" bash "$REPO_DIR/install.sh" >/dev/null 2>&1)
+
+    local valid=true
+    [ ! -e "$REPO_DIR/.codex/hooks/sdlc-prompt-check.sh" ] || valid=false
+    [ ! -e "$tmpdir/.codex/hooks/sdlc-prompt-check.sh" ] || valid=false
+    grep -Fq '# user customization' "$custom_tmpdir/.codex/hooks/sdlc-prompt-check.sh" || valid=false
+    grep -Fq 'sdlc-prompt-check.sh' "$REPO_DIR/install.sh" && valid=false
+    grep -Fq 'remove-retired-files.cjs' "$REPO_DIR/install.sh" || valid=false
+    grep -Fq 'remove-retired-files.cjs' "$REPO_DIR/install.ps1" || valid=false
+    grep -Fq 'remove-retired-files.cjs' "$REPO_DIR/update.sh" || valid=false
+    rm -rf "$tmpdir" "$custom_tmpdir"
+
+    if [ "$valid" = "true" ]; then
+        pass "installers remove only the unchanged retired prompt hook"
+    else
+        fail "installers retained the wizard-owned prompt hook or removed a customization"
+    fi
+}
+
+test_installers_share_agents_ownership_messages() {
+    local valid=true
+    for installer in "$REPO_DIR/install.sh" "$REPO_DIR/install.ps1"; do
+        grep -Fq 'CODEX_SDLC_SETUP_GENERATED_AGENTS' "$installer" || valid=false
+        grep -Fq 'AGENTS.md generated earlier in this setup - keeping it' "$installer" || valid=false
+        grep -Fq 'AGENTS.md already matches the wizard baseline - keeping it' "$installer" || valid=false
+        grep -Fq 'AGENTS.md is wizard-managed - keeping it; profile guidance will be refreshed if needed' "$installer" || valid=false
+        grep -Fq 'AGENTS.md is user-owned or customized - preserving it' "$installer" || valid=false
+    done
+    grep -Fq ') -ceq $content)' "$REPO_DIR/install.ps1" || valid=false
+
+    if [ "$valid" = "true" ]; then
+        pass "shell and PowerShell installers share explicit AGENTS.md ownership messages"
+    else
+        fail "shell and PowerShell installers do not share AGENTS.md ownership semantics"
     fi
 }
 
@@ -2155,7 +2232,7 @@ test_install_rejects_malformed_hooks_without_overwrite() {
 }
 
 test_install_refreshes_unmodified_agents_for_profile_switch() {
-    local tmpdir output valid=true
+    local tmpdir install_output output valid=true
     tmpdir=$(mktemp -d)
     echo '{"name":"profile-switch","scripts":{"test":"jest"}}' > "$tmpdir/package.json"
     mkdir -p "$tmpdir/src"
@@ -2181,16 +2258,18 @@ manifest.managed_files["AGENTS.md"] = `sha256:${crypto.createHash("sha256").upda
 fs.writeFileSync(process.env.MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
 NODE
 
-    (
+    install_output=$(
         umask 077 && cd "$tmpdir" && \
         CODEX_HOME="$tmpdir/.codex-home" \
-        bash "$REPO_DIR/install.sh" --model-profile maximum >/dev/null 2>&1
+        bash "$REPO_DIR/install.sh" --model-profile maximum 2>&1
     ) || valid=false
     output=$(cd "$tmpdir" && bash "$REPO_DIR/check.sh" 2>/dev/null)
 
     grep -Fq -- '- Selected profile: `maximum`' "$tmpdir/AGENTS.md" || valid=false
     grep -Fq -- '- Baseline reasoning: `high`' "$tmpdir/AGENTS.md" || valid=false
     ! grep -Fq -- '- Selected profile: mixed' "$tmpdir/AGENTS.md" || valid=false
+    echo "$install_output" | grep -Fq 'AGENTS.md is wizard-managed - keeping it; profile guidance will be refreshed if needed' || valid=false
+    echo "$install_output" | grep -Fq 'AGENTS.md is user-owned or customized - preserving it' && valid=false
     CHECK_OUTPUT="$output" node <<'NODE' || valid=false
 const data = JSON.parse(process.env.CHECK_OUTPUT);
 if (data.managed_files?.["AGENTS.md"]?.status !== "match") process.exit(1);
@@ -3084,6 +3163,23 @@ test_readme_mentions_npx_entrypoint() {
     fi
 }
 
+test_readme_explains_plugin_to_daily_workflow() {
+    local readme="$REPO_DIR/README.md"
+    local valid=true
+
+    grep -Fq '## Which entry point should I use?' "$readme" || valid=false
+    grep -Fq '`/plugins`' "$readme" || valid=false
+    grep -Fq '`$codex-sdlc-wizard`' "$readme" || valid=false
+    grep -Fq '`$sdlc`' "$readme" || valid=false
+    grep -Fq 'Ordinary Chat' "$readme" || valid=false
+
+    if [ "$valid" = "true" ]; then
+        pass "README explains plugin installation, repo setup, and daily SDLC as separate steps"
+    else
+        fail "README lacks a concise plugin-to-installer-to-daily-workflow decision path"
+    fi
+}
+
 test_e2e_requires_explicit_token_opt_in() {
     if grep -q 'CODEX_E2E:-0' "$REPO_DIR/tests/test-e2e.sh" \
         && grep -q 'CODEX_E2E=1 bash tests/test-e2e.sh' "$REPO_DIR/README.md" \
@@ -3154,6 +3250,9 @@ test_live_hooks_file_uses_universal_node_hooks
 test_live_hooks_file_is_windows_safe
 test_config_enables_hooks
 test_install_preserves_agents_md
+test_install_reports_current_agents_baseline
+test_install_omits_inactive_prompt_hook
+test_installers_share_agents_ownership_messages
 test_install_creates_sdlc_docs
 test_install_creates_skill
 test_install_keeps_skill_backups_out_of_skills_and_prunes_legacy_sdlc
@@ -3195,6 +3294,7 @@ test_package_cli_help_mentions_update
 test_package_cli_runs_check_command
 test_package_cli_runs_update_command
 test_readme_mentions_npx_entrypoint
+test_readme_explains_plugin_to_daily_workflow
 test_e2e_requires_explicit_token_opt_in
 test_e2e_bypasses_hook_trust_only_for_ephemeral_automation
 test_docs_document_proof_stamp_gate

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -426,6 +426,25 @@ test_setup_generates_sdlc_md() {
     fi
 }
 
+test_setup_reports_agents_generated_in_same_transaction() {
+    local ws output valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/sdlc-test.XXXXXX")
+    echo '{"name":"test-app","scripts":{"test":"jest"}}' > "$ws/package.json"
+    mkdir -p "$ws/src"
+
+    output=$(run_setup "$ws")
+    [ -f "$ws/AGENTS.md" ] || valid=false
+    echo "$output" | grep -Fq 'AGENTS.md generated earlier in this setup - keeping it' || valid=false
+    echo "$output" | grep -Fq 'AGENTS.md already exists - skipping (review manually)' && valid=false
+    rm -rf "$ws"
+
+    if [ "$valid" = "true" ]; then
+        pass "setup reports AGENTS.md generated earlier in the same transaction"
+    else
+        fail "setup misleadingly reports its newly generated AGENTS.md as pre-existing"
+    fi
+}
+
 # ---- Test 16: optional GOALS.md active-scope contract ----
 test_setup_goals_template_is_explicit_opt_in() {
     local default_ws preexisting_ws goals_ws
@@ -1691,6 +1710,7 @@ test_template_testing_md_domain
 test_generated_no_placeholders
 test_agents_md_read_directives
 test_setup_generates_sdlc_md
+test_setup_reports_agents_generated_in_same_transaction
 test_setup_goals_template_is_explicit_opt_in
 test_setup_rejects_unknown_arguments
 test_setup_generates_demo_runtime_claim_gate

--- a/tests/test-update.sh
+++ b/tests/test-update.sh
@@ -1529,6 +1529,184 @@ NODE
     fi
 }
 
+test_update_removes_only_unmodified_retired_prompt_hook() {
+    local ws custom_ws referenced_ws missing_ws missing_referenced_ws valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    custom_ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    referenced_ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    missing_ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    missing_referenced_ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+
+    for target_ws in "$ws" "$custom_ws" "$referenced_ws" "$missing_ws" "$missing_referenced_ws"; do
+        echo '{"name":"test-app","scripts":{"test":"jest"}}' > "$target_ws/package.json"
+        mkdir -p "$target_ws/src"
+        run_setup_local "$target_ws"
+        printf '%s\n' \
+            '#!/bin/bash' \
+            "cat << 'EOF'" \
+            'SDLC BASELINE:' \
+            '1. Plan before coding — state confidence level' \
+            '2. TDD: Write failing test FIRST, then implement' \
+            '3. ALL tests must pass before commit' \
+            '4. Self-review before presenting to user' \
+            'EOF' > "$target_ws/.codex/hooks/sdlc-prompt-check.sh"
+        MANIFEST_PATH="$target_ws/.codex-sdlc/manifest.json" node <<'NODE'
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, "utf8"));
+manifest.managed_files[".codex/hooks/sdlc-prompt-check.sh"] =
+  "sha256:84ba0abfdf7b55849dd925a726c5de77d713d83efd9c50b19dfa06ff38f28112";
+fs.writeFileSync(process.env.MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+    done
+    printf '%s\n' '# user customization' >> "$custom_ws/.codex/hooks/sdlc-prompt-check.sh"
+    if [ "$IS_WINDOWS" = "false" ] && [ ! -e "$referenced_ws/.Codex" ]; then
+        ln -s .codex "$referenced_ws/.Codex"
+    fi
+    HOOKS_PATH="$referenced_ws/.codex/hooks.json" node <<'NODE'
+const fs = require("fs");
+const hooks = JSON.parse(fs.readFileSync(process.env.HOOKS_PATH, "utf8"));
+hooks.hooks.UserPromptSubmit = [{
+  hooks: [{ type: "command", command: "bash -x .Codex/hooks/sdlc-prompt-check.sh" }],
+}];
+fs.writeFileSync(process.env.HOOKS_PATH, `${JSON.stringify(hooks, null, 2)}\n`);
+NODE
+    HOOKS_PATH="$referenced_ws/.codex/hooks.json" node <<'NODE'
+const fs = require("fs");
+fs.writeFileSync(process.env.HOOKS_PATH, `\uFEFF${fs.readFileSync(process.env.HOOKS_PATH, "utf8")}`);
+NODE
+    rm -f "$custom_ws/TESTING.md"
+    rm -f "$missing_ws/.codex/hooks/sdlc-prompt-check.sh"
+    HOOKS_PATH="$missing_referenced_ws/.codex/hooks.json" node <<'NODE'
+const fs = require("fs");
+const hooks = JSON.parse(fs.readFileSync(process.env.HOOKS_PATH, "utf8"));
+hooks.hooks.UserPromptSubmit = [{
+  hooks: [{ type: "command", command: "bash -x .codex/hooks/sdlc-prompt-check.sh" }],
+}];
+fs.writeFileSync(process.env.HOOKS_PATH, `${JSON.stringify(hooks, null, 2)}\n`);
+NODE
+    rm -f "$missing_referenced_ws/.codex/hooks/sdlc-prompt-check.sh"
+    if [ "$IS_WINDOWS" = "false" ]; then
+        chmod 664 "$missing_ws/.codex-sdlc/manifest.json"
+    fi
+
+    local custom_plan referenced_plan referenced_second_plan missing_referenced_plan missing_referenced_status second_output check_output custom_check_output referenced_check_output
+    custom_plan=$(run_update "$custom_ws" check-only) || valid=false
+    echo "$custom_plan" | grep -Fq '.codex/hooks/sdlc-prompt-check.sh: retired manifest ownership -> remove ownership (preserve file)' || valid=false
+    echo "$custom_plan" | grep -Fq '.codex/hooks/sdlc-prompt-check.sh: retired wizard file -> remove' && valid=false
+    referenced_plan=$(run_update "$referenced_ws" check-only) || valid=false
+    echo "$referenced_plan" | grep -Fq '.codex/hooks/sdlc-prompt-check.sh: retired manifest ownership -> remove ownership (preserve file)' || valid=false
+    echo "$referenced_plan" | grep -Fq '.codex/hooks/sdlc-prompt-check.sh: retired wizard file -> remove' && valid=false
+    run_update "$ws" >/dev/null || valid=false
+    run_update "$custom_ws" >/dev/null || valid=false
+    run_update "$referenced_ws" >/dev/null || valid=false
+    referenced_second_plan=$(run_update "$referenced_ws" check-only) || valid=false
+    echo "$referenced_second_plan" | grep -Fq 'Check only: no changes applied.' || valid=false
+    echo "$referenced_second_plan" | grep -Fq '.codex/hooks/sdlc-prompt-check.sh:' && valid=false
+    set +e
+    missing_referenced_plan=$(run_update "$missing_referenced_ws" check-only)
+    missing_referenced_status=$?
+    set -e
+    [ "$missing_referenced_status" -ne 0 ] || valid=false
+    echo "$missing_referenced_plan" | grep -Fq '.codex/hooks/sdlc-prompt-check.sh: retained hook target missing -> manual repair required' || valid=false
+    (umask 077; run_update "$missing_ws" >/dev/null) || valid=false
+    second_output=$(run_update "$ws") || valid=false
+    check_output=$(cd "$ws" && bash "$CHECK_SH") || valid=false
+    custom_check_output=$(cd "$custom_ws" && bash "$CHECK_SH") || valid=false
+    referenced_check_output=$(cd "$referenced_ws" && bash "$CHECK_SH") || valid=false
+
+    [ ! -e "$ws/.codex/hooks/sdlc-prompt-check.sh" ] || valid=false
+    grep -Fq '# user customization' "$custom_ws/.codex/hooks/sdlc-prompt-check.sh" || valid=false
+    [ -f "$referenced_ws/.codex/hooks/sdlc-prompt-check.sh" ] || valid=false
+    grep -Fq 'bash -x .Codex/hooks/sdlc-prompt-check.sh' "$referenced_ws/.codex/hooks.json" || valid=false
+    echo "$second_output" | grep -Fq 'No changes applied.' || valid=false
+    for manifest_path in "$ws/.codex-sdlc/manifest.json" "$custom_ws/.codex-sdlc/manifest.json" "$referenced_ws/.codex-sdlc/manifest.json" "$missing_ws/.codex-sdlc/manifest.json"; do
+        MANIFEST_PATH="$manifest_path" node <<'NODE' || valid=false
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, "utf8"));
+if (Object.prototype.hasOwnProperty.call(manifest.managed_files, ".codex/hooks/sdlc-prompt-check.sh")) process.exit(1);
+NODE
+    done
+    MANIFEST_PATH="$missing_referenced_ws/.codex-sdlc/manifest.json" node <<'NODE' || valid=false
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, "utf8"));
+if (!Object.prototype.hasOwnProperty.call(manifest.managed_files, ".codex/hooks/sdlc-prompt-check.sh")) process.exit(1);
+NODE
+    if [ "$IS_WINDOWS" = "false" ]; then
+        MANIFEST_PATH="$missing_ws/.codex-sdlc/manifest.json" node <<'NODE' || valid=false
+const fs = require("fs");
+if ((fs.statSync(process.env.MANIFEST_PATH).mode & 0o777) !== 0o664) process.exit(1);
+NODE
+    fi
+    CHECK_OUTPUT="$check_output" CUSTOM_CHECK_OUTPUT="$custom_check_output" REFERENCED_CHECK_OUTPUT="$referenced_check_output" node <<'NODE' || valid=false
+for (const value of [process.env.CHECK_OUTPUT, process.env.CUSTOM_CHECK_OUTPUT, process.env.REFERENCED_CHECK_OUTPUT]) {
+  const data = JSON.parse(value);
+  if (data.summary?.missing !== 0 || data.summary?.["drift / broken"] !== 0) process.exit(1);
+}
+NODE
+    rm -rf "$ws" "$custom_ws" "$referenced_ws" "$missing_ws" "$missing_referenced_ws"
+
+    if [ "$valid" = "true" ]; then
+        pass "update retires legacy prompt-hook files and manifest ownership safely"
+    else
+        fail "update left retired prompt-hook drift or removed a customization"
+    fi
+}
+
+test_update_rejects_dangling_retained_prompt_hook_symlink() {
+    if [ "$IS_WINDOWS" = "true" ]; then
+        pass "dangling retained prompt-hook symlink check is POSIX-only"
+        return
+    fi
+
+    local ws status_output mutation_status valid=true
+    ws=$(mktemp -d "$MKTEMP_DIR/update-test.XXXXXX")
+    mkdir -p "$ws/.codex/hooks" "$ws/.codex-sdlc"
+    ln -s missing-custom-target "$ws/.codex/hooks/sdlc-prompt-check.sh"
+    cat > "$ws/.codex/hooks.json" <<'JSON'
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -x .codex/hooks/sdlc-prompt-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+JSON
+    cat > "$ws/.codex-sdlc/manifest.json" <<'JSON'
+{
+  "managed_files": {
+    ".codex/hooks/sdlc-prompt-check.sh": "sha256:84ba0abfdf7b55849dd925a726c5de77d713d83efd9c50b19dfa06ff38f28112"
+  }
+}
+JSON
+
+    status_output=$(cd "$ws" && node "$REPO_DIR/lib/remove-retired-files.cjs" --status) || valid=false
+    echo "$status_output" | grep -Fq $'.codex/hooks/sdlc-prompt-check.sh\tretained-missing' || valid=false
+    set +e
+    (cd "$ws" && node "$REPO_DIR/lib/remove-retired-files.cjs" >/dev/null 2>&1)
+    mutation_status=$?
+    set -e
+    [ "$mutation_status" -ne 0 ] || valid=false
+    MANIFEST_PATH="$ws/.codex-sdlc/manifest.json" node <<'NODE' || valid=false
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.env.MANIFEST_PATH, "utf8"));
+if (!Object.prototype.hasOwnProperty.call(manifest.managed_files, ".codex/hooks/sdlc-prompt-check.sh")) process.exit(1);
+NODE
+    rm -rf "$ws"
+
+    if [ "$valid" = "true" ]; then
+        pass "update rejects dangling retained prompt-hook symlinks as missing targets"
+    else
+        fail "update accepted a dangling retained prompt-hook symlink"
+    fi
+}
+
 test_update_reports_uninitialized_repo
 test_update_check_only_reports_missing_without_repair
 test_update_repairs_missing_generated_docs
@@ -1559,6 +1737,8 @@ test_update_refreshes_generated_policy_when_profile_metadata_is_missing
 test_update_refreshes_legacy_policy_surfaces_without_overwriting_customizations
 test_update_migrates_legacy_policy_around_customized_profile_metadata
 test_update_records_schema_only_migration_when_all_policy_surfaces_are_customized
+test_update_removes_only_unmodified_retired_prompt_hook
+test_update_rejects_dangling_retained_prompt_hook_symlink
 
 echo ""
 echo "=== Results: $PASSED passed, $FAILED failed ==="

--- a/update.sh
+++ b/update.sh
@@ -447,6 +447,26 @@ declare -a REGENERATE_EXISTING_DOCS=()
 CHANGES_PENDING=false
 RUN_REGENERATE=false
 REGENERATE_FORCE=false
+RETIRED_PROMPT_HOOK_STATUS="$(
+    node "$SCRIPT_DIR/lib/remove-retired-files.cjs" --status |
+        awk -F '\t' '$1 == ".codex/hooks/sdlc-prompt-check.sh" { print $2 }'
+)"
+RETIRED_PROMPT_HOOK_BLOCKED=false
+
+case "$RETIRED_PROMPT_HOOK_STATUS" in
+    wizard-managed)
+        PLAN_LINES+=(".codex/hooks/sdlc-prompt-check.sh|retired wizard file|remove")
+        CHANGES_PENDING=true
+        ;;
+    tracked-retired)
+        PLAN_LINES+=(".codex/hooks/sdlc-prompt-check.sh|retired manifest ownership|remove ownership (preserve file)")
+        CHANGES_PENDING=true
+        ;;
+    retained-missing)
+        PLAN_LINES+=(".codex/hooks/sdlc-prompt-check.sh|retained hook target missing|manual repair required")
+        RETIRED_PROMPT_HOOK_BLOCKED=true
+        ;;
+esac
 
 array_contains() {
     local needle="$1"
@@ -500,6 +520,7 @@ queue_regenerate_existing_doc() {
 for line in "${STATUS_LINES[@]}"; do
     IFS=$'\t' read -r relative_path status <<< "$line"
     [ -n "$relative_path" ] || continue
+    [ "$relative_path" != ".codex/hooks/sdlc-prompt-check.sh" ] || continue
 
     action="keep"
     if [ "$relative_path" = ".codex/hooks.json" ]; then
@@ -715,6 +736,13 @@ for plan_line in "${PLAN_LINES[@]}"; do
     echo "- $relative_path: $status -> $action"
 done
 
+if [ "$RETIRED_PROMPT_HOOK_BLOCKED" = "true" ]; then
+    echo ""
+    echo "Update cannot continue: a retained custom hook references missing .codex/hooks/sdlc-prompt-check.sh." >&2
+    echo "Restore that customized target or remove the retained hook command, then rerun update." >&2
+    exit 1
+fi
+
 if [ "$CHECK_ONLY" = "true" ]; then
     echo ""
     echo "Check only: no changes applied."
@@ -731,6 +759,9 @@ require_gpt56_codex_version
 
 echo ""
 echo "Applying planned updates..."
+if [ "$RETIRED_PROMPT_HOOK_STATUS" = "wizard-managed" ] || [ "$RETIRED_PROMPT_HOOK_STATUS" = "tracked-retired" ]; then
+    node "$SCRIPT_DIR/lib/remove-retired-files.cjs"
+fi
 if [ "${#STATIC_REPAIRS[@]}" -gt 0 ]; then
     for relative_path in "${STATIC_REPAIRS[@]}"; do
         repair_managed_file "$relative_path"


### PR DESCRIPTION
## Summary

- stop installing the inactive unmanaged `sdlc-prompt-check.sh` helper
- distinguish wizard-generated, wizard-managed, and user-owned `AGENTS.md` first-run states
- preserve genuine user customizations across shell and PowerShell paths
- remove retired managed files safely during update

## Root cause

The Desktop E2E found that setup copied an inactive hook outside the managed manifest and that nested first-run output described an `AGENTS.md` created by the same transaction as though it were an unknown user customization.

## Verification

- 11/11 full proof checks passed on the exact staged tree
- exact-diff self-review clean
- independent Sol review clean
- final Fable review clean
- `git diff --cached --check` passed before commit

Closes #76