### PR TITLE
docs: add Windows Desktop real-install E2E runbook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Use the default `maximum` profile for normal work: GPT-5.6 Sol at `high`. The `m
 
 These workflows work in Codex Desktop, Codex CLI, and ChatGPT Work when the active project can access the repository and a shell. Ordinary Chat can display the installed plugin in its directory but cannot invoke repo-local skills; switch to Work or Codex for installation and delivery work.
 
+For a Claude-driven Windows adoption test against a real product repository, use the [Windows Codex Desktop real-install E2E](WINDOWS-CODEX-DESKTOP-E2E.md) runbook.
+
 ## Quick Start
 
 ```bash

--- a/WINDOWS-CODEX-DESKTOP-E2E.md
+++ b/WINDOWS-CODEX-DESKTOP-E2E.md
@@ -1,0 +1,172 @@
+# Windows Codex Desktop Real-Install E2E
+
+This runbook lets Claude Desktop use computer control to drive Codex Desktop through an authorized real installation of Codex SDLC Wizard in an existing Windows product repository. It is both an adoption procedure and a black-box E2E test.
+
+Do not use `codex-sdlc-wizard` itself as the target repository. This repository contains the runbook and wizard source; the target must be the separate product repository where SDLC guardrails should be installed.
+
+## What to paste into Claude Desktop
+
+Open Claude Desktop in a fresh session with computer use enabled, then paste exactly:
+
+```text
+Use computer control to operate Codex Desktop on this Windows machine. Read WINDOWS-CODEX-DESKTOP-E2E.md from the current codex-sdlc-wizard checkout and execute the complete runbook. The installation target is the separate product repository currently open in Codex Desktop. Do not install the wizard into its own source repository. Do not commit, push, tag, publish, deploy, or begin product implementation. Return the required evidence report when finished.
+```
+
+If Codex Desktop is not already open to the intended product repository, Claude must stop and ask for the target repository rather than guessing.
+
+## Operating contract
+
+- Use Claude Desktop only as the external computer-use operator. Perform the repository work through the visible Codex Desktop user interface.
+- Use GPT-5.6 Sol at `high` reasoning. Do not use `xhigh` for this consumer-repository installation.
+- Preserve every existing source file, document, hook, configuration file, customization, and uncommitted change.
+- Do not clean, stash, reset, discard, or commit existing work.
+- Do not commit, push, tag, publish, deploy, or open a pull request during this run.
+- Do not manually delete `.codex`, `.agents`, `.codex-sdlc`, `AGENTS.md`, or existing SDLC documents.
+- Do not uninstall the plugin initially. Inspect the current state first.
+- If a wizard defect occurs, gather exact evidence and stop the affected phase. Do not modify the cached plugin or wizard source to hide the failure.
+- Never include secrets, tokens, private source contents, or customer data in the final report.
+- Redact secrets, tokens, private source text, and customer data from every warning, error, transcript, and screenshot included in the report. Replace only sensitive values with `[REDACTED]` so the diagnostic shape remains useful.
+
+## Phase 1: Establish the real target and baseline
+
+1. Bring Codex Desktop to the foreground.
+2. Report the repository name and absolute Windows path shown by Codex.
+3. Stop if the selected target is the `codex-sdlc-wizard` source repository.
+4. Confirm the selected directory is the intended real product repository.
+5. Confirm the separate `codex-sdlc-wizard` checkout is at the intended committed candidate and has no modified, staged, or untracked files. Stop if it is dirty. Export its committed `HEAD` without changing the checkout: run `git -C "<wizard-checkout>" archive --format=zip --output="<temporary-directory>\wizard-head.zip" HEAD`, expand that archive outside both repositories, and record the expanded directory as `<verified-head-export>`. The repository's `.gitattributes` pins `*.sh` to LF for normal checkouts; the committed export additionally avoids treating a pre-existing CRLF working tree as candidate payload.
+6. In Codex, run read-only inspection commands to record:
+   - Windows version and architecture
+   - Codex Desktop and Codex CLI versions
+   - Node.js and Git versions
+   - repository root, branch, and `git status --short --branch`
+   - configured remotes without contacting or changing them
+   - the expected Codex SDLC Wizard release version from `<verified-head-export>\package.json`
+   - an exact canonical candidate-payload manifest for every shipped file selected by the committed export's `package.json` `files` plus automatically included `package.json`; derive the path list with `npm pack "<verified-head-export>" --dry-run --json` and sort paths ordinally. In the committed export and every plugin or extracted-package source being compared, inspect each shipped `.sh` file as raw bytes before hashing: stop if it contains any carriage-return byte (including CRLF), and hash accepted `.sh` bytes exactly unchanged. Git Bash requires LF-only shell payloads. For other UTF-8 text, normalize CRLF and lone CR to LF before SHA-256 hashing; hash binary bytes unchanged. For `.codex-plugin/plugin.json`, parse JSON, canonicalize only the platform-generated `+codex...` suffix out of the top-level `version`, recursively sort object keys, and serialize compact UTF-8 JSON before hashing in every compared source; still record and compare the visible full plugin version separately.
+7. Stop before plugin or npm work if Codex CLI is older than `0.144.0` or Node.js is older than 18. Report the unsupported prerequisite; do not let an update mutate the repository first.
+
+Before continuing, run `Get-Command bash -ErrorAction SilentlyContinue`, `bash --version`, and `bash -lc 'uname -s'` in PowerShell. Continue only when `uname` identifies an MSYS, MINGW, or CYGWIN environment. A WSL launcher named `bash.exe` is not Git Bash and cannot safely consume the Windows package paths used here. If compatible Bash is unavailable on `PATH`, stop before plugin mutation or npm fallback and report that this adaptive E2E requires Git Bash.
+
+8. Record whether these paths already exist:
+   - `AGENTS.md`
+   - `.codex/config.toml`
+   - `.codex/hooks.json`
+   - `.agents/skills/sdlc/SKILL.md`
+   - `.codex-sdlc/`
+   - `SDLC.md`
+   - `TESTING.md`
+   - `ARCHITECTURE.md`
+9. If `.codex-sdlc/manifest.json` exists but is invalid JSON or lacks the expected manifest object, stop before plugin inspection, setup, or update. A broken manifest is neither initialized nor safely uninitialized, and setup can partially mutate the repository before failing.
+10. If `.codex/hooks.json` exists, parse and validate it before any setup, update, plugin mutation, or fallback execution. Require a JSON object; when `hooks` exists, require it to be an object whose event values are arrays, whose entries contain `hooks` arrays, and whose hook entries are objects with string `command` values when present. If `.codex/hooks.json` is invalid, stop before setup or mutation. Do not let setup create documents before discovering malformed hook configuration.
+11. If `.codex-sdlc/manifest.json` is valid, record the repository as initialized and record its existing selected profile. An initialized update must preserve that selected profile unless the user separately authorizes migration.
+12. If the repository is uninitialized, stop when any unconditional installer target already exists: `.codex-sdlc/model-profile.json`, `.codex/hooks/bash-guard.sh`, `.codex/hooks/session-start.sh`, `.codex/hooks/git-guard.cjs`, `.codex/hooks/session-start.cjs`, `.codex/hooks/compact-guard.cjs`, `.codex/hooks/git-guard.ps1`, `.codex/hooks/session-start.ps1`, `.codex/hooks/git-guard.js`, or `.codex/hooks/session-start.js`. The model-profile file is an unconditional destructive collision because setup rewrites it, while the two `.js` names are retired targets that current setup removes. Perform this collision preflight before either the plugin path or npm fallback.
+13. Hash every pre-existing modified or untracked path reported by Git, recursively hashing files inside dirty directories. Record deleted paths as absent. Also hash every pre-existing manifest-managed path and every pre-existing installer-targeted path named in steps 8 and 12, regardless of Git status; this includes ignored wizard files that update may rewrite. If every dirty, managed, and installer-targeted path cannot be captured, stop rather than claim preservation from Git status alone.
+14. Resolve the active Codex home (normally `%USERPROFILE%\.codex`) and record existence plus recursive file hashes—never file contents—for its `skills\feedback`, `skills\setup-wizard`, `skills\update-wizard`, `skills\sdlc`, `skills\codex-sdlc`, `skills\codex-sdlc-wizard`, `backups\skills`, and `skill-backups` paths. The last two backup locations are distinct. These user-level mutations and legacy-installer migrations do not appear in repository Git status.
+15. Preserve the complete baseline output for the final comparison.
+
+## Phase 2: Inspect the plugin before changing it
+
+1. Open Codex Desktop's Plugins interface.
+2. Inspect both **Personal** and **Installed**.
+3. Find **Codex SDLC Wizard** and record:
+   - exact plugin version
+   - installed/enabled state
+   - whether duplicate plugin or installer entries appear
+4. If the plugin is visible but not installed, use **Install**. If it is installed but disabled or not enabled, use **Enable**.
+5. Compare the plugin's release version with the expected version recorded from this checkout's `package.json`, but do not treat a version-only match as candidate identity.
+6. If the interface offers an Update or Reinstall action for an older or mismatched version, use that action and verify the version again.
+7. Only uninstall and reinstall the plugin package when no in-place update path exists. Do not remove repository-local guardrails as part of a plugin reinstall.
+8. If duplicate legacy installer skills appear, record their labels and scopes. Use only the wizard's documented recoverable legacy-skill cleanup; do not delete repository data.
+9. Start a fresh Codex session after any plugin installation, enablement, update, reinstall, or legacy-skill cleanup.
+10. Resolve the active installer skill's source path from Codex's visible work log and derive its native Windows plugin root. Convert it for Git Bash with `bash -lc 'cygpath -u "$1"' -- "<native-plugin-root>"` and record the result as `<verified-plugin-root>`. Recompute the complete canonical payload manifest using the exact Phase 1 path list and normalization rules. Every shipped payload path and hash must match before the plugin path can mutate the target; missing or extra expected payload files fail identity. A matching release-version label or `+codex...` build suffix alone is insufficient.
+
+If the plugin is unavailable through the visible interface, or its exact payload manifest remains stale/mismatched after the supported update or reinstall path, use the exact committed `HEAD` export prepared in Phase 1 as the candidate fallback instead of resolving a registry dist-tag or packing potentially CRLF-converted working-tree files. Confirm that the Phase 1 Git Bash compatibility preflight passed, then run `npm pack "<verified-head-export>" --pack-destination "<temporary-directory>"` and extract that tarball outside both repositories. Do not use `@latest` for this candidate test. Recompute the complete canonical payload manifest for the extracted package using the Phase 1 path list and normalization rules. Every payload hash and the package version must match before execution. If either comparison differs, stop because neither available path can validate the intended candidate.
+
+Execute the already verified extracted package directly; do not use `npx` after verification because it can resolve a different dist-tag or cached package. Choose the command from repository state, substituting the absolute extracted-package path for `<verified-package>`:
+
+- Initialized repository (a valid `.codex-sdlc/manifest.json` exists): `node "<verified-package>\bin\codex-sdlc-wizard.js" update`
+- Uninitialized repository: `node "<verified-package>\bin\codex-sdlc-wizard.js" setup --yes --model-profile maximum`
+
+Do not install the npm package globally. Record that the verified-package fallback was required. When the selected command finishes, run `node "<verified-package>\bin\codex-sdlc-wizard.js" check` and capture the result. Keep the verified package through Phase 4 so the same trusted check command remains available, and remove its temporary directory only after the preservation comparison in Phase 5. Restart Codex Desktop in the same target repository, skip Phase 3, and continue with Phase 4. This npm fallback performs the repo operation directly and does not make the plugin-only `$codex-sdlc-wizard` installer entry available.
+
+## Phase 3: Install or repair the real product repository
+
+Skip this phase when the npm fallback completed successfully; it already performed the repository setup. This phase is only for the plugin UI path.
+
+1. Reopen the target product repository in Codex Desktop.
+2. Inspect `.codex-sdlc/manifest.json` and the existing `.codex/hooks/` scripts before mutation.
+3. Search for `$codex-sdlc-wizard` and select **Install SDLC Guardrails**.
+4. Give Codex this instruction, replacing `<verified-plugin-root>` with the exact plugin root fingerprinted in Phase 2:
+
+   ```text
+   Install or repair Codex SDLC guardrails in this repository using only the verified plugin payload. If the repository is initialized, preserve its existing selected profile and run exactly `bash "<verified-plugin-root>/update.sh"`. If it is uninitialized, confirm the Phase 1 collision preflight passed and run exactly `bash "<verified-plugin-root>/setup.sh" --yes --model-profile maximum`. After either operation, run exactly `bash "<verified-plugin-root>/check.sh"`. Do not use npx or any other package copy. Preserve every existing customization, document, hook, configuration file, application file, and uncommitted change. Do not commit or push.
+   ```
+
+5. Allow the selected bundled setup/update/check workflow to finish.
+6. Do not substitute raw package edits or manual generated-file changes for a failed installer step.
+7. Capture all visible output, warnings, approval requests, exit codes, created-file counts, and verification results.
+8. If the operation recommends a restart, fully restart Codex Desktop or start a fresh session rooted in the same repository.
+
+## Phase 4: Verify the installed workflow
+
+1. Confirm Codex reopens the target repository without a hook, configuration, locale, or startup error.
+2. Open `/hooks`. Review any pending repository hooks and confirm the wizard hooks are approved and active before relying on enforcement or declaring the install ready.
+3. Confirm `$sdlc` appears exactly once and is scoped to the target repository.
+4. Invoke `$sdlc` with this read-only request:
+
+   ```text
+   Inspect the installed SDLC configuration and explain the active model profile, planning policy, TDD requirements, verification requirements, review gates, and commit/push rules. Cite the repo files that define each rule. Do not edit files and do not claim that any review has already passed.
+   ```
+
+5. Run the bundled wizard check from the same verified source used for mutation and capture its complete structured result: `bash "<verified-plugin-root>/check.sh"` for the plugin path, or `node "<verified-package>\bin\codex-sdlc-wizard.js" check` for the verified-package fallback.
+6. Confirm all of the following:
+   - repository state is initialized
+   - an uninitialized installation selected `maximum`; an initialized update preserved the selected profile recorded in Phase 1
+   - the driver matches the preserved/selected profile: `maximum` uses `gpt-5.6-sol` at `high`; an explicitly preserved `mixed` profile uses `gpt-5.6-terra` at `medium` with `gpt-5.6-sol` review explicitly set to `high`
+   - required managed artifacts are present
+   - no managed artifact is missing or drifted/broken
+   - existing customizations are preserved according to the complete baseline comparison; preserved files may report as `match` when first recorded in a new manifest, while `customized` is reserved for drift from an existing manifest
+   - there is no duplicate legacy `$codex-sdlc` or duplicate wizard installer entry
+   - the post-install Git status contains only intentional wizard installation changes plus the exact pre-existing changes
+
+## Phase 5: Preservation comparison
+
+1. Re-run the baseline Git status and file hashes.
+2. Compare every pre-existing modified/untracked path against the baseline.
+3. Compare the recorded Codex-home skill and backup paths, and disclose every user-level skill replacement, backup, migration, or removal.
+4. Explain every new or changed wizard-managed path.
+5. Treat an unexplained change to application code, an existing customization, or a user-level Codex skill as a failure.
+6. Do not repair a preservation failure locally. Preserve evidence for the upstream issue.
+7. After all comparisons and evidence capture finish, remove any temporary verified-package extraction outside the target repository.
+
+## Required final report
+
+Return one of: **PASS**, **PASS WITH FOLLOW-UP**, or **FAIL**.
+
+Include:
+
+- target repository name and absolute path
+- Windows version and architecture
+- Codex Desktop, Codex CLI, Node.js, Git, expected checkout, plugin, npm package, and adapter versions, including whether the plugin release version matched the checkout
+- installation path used: plugin UI or verified-package fallback
+- before/after Git status
+- files created, updated, preserved, customized, missing, or drifted/broken
+- complete wizard check counts and repository/profile state
+- whether restart succeeded cleanly
+- whether `$sdlc` appeared exactly once and answered correctly
+- every warning or error with diagnostic wording preserved but all sensitive values redacted
+- redacted screenshots or visible transcript evidence
+- confirmation that no commit, push, tag, publish, deployment, or PR occurred
+- whether the repository is ready for normal work with `$sdlc`
+
+For every defect, append a **GitHub-issue-ready** block containing:
+
+- concise title
+- severity and user impact
+- expected behavior
+- actual behavior
+- exact reproduction steps
+- environment and versions
+- relevant logs/output with secrets removed
+- workaround, only if one was safely verified without changing wizard internals
+
+Stop after the report. Do not begin the product's implementation work until the installation result is accepted.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "update.sh",
     "AGENTS.md",
     "README.md",
+    "WINDOWS-CODEX-DESKTOP-E2E.md",
     "ROADMAP.md",
     "SDLC-LOOP.md",
     "START-SDLC.md",

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -2975,6 +2975,7 @@ test_package_has_npm_release_surface() {
         "update.sh" \
         "AGENTS.md" \
         "README.md" \
+        "WINDOWS-CODEX-DESKTOP-E2E.md" \
         "ROADMAP.md" \
         "SDLC-LOOP.md" \
         "START-SDLC.md" \

--- a/tests/test-npm.sh
+++ b/tests/test-npm.sh
@@ -95,6 +95,7 @@ test_npm_pack_includes_runtime_files() {
     local has_openai_yaml=true
     local has_repo_sdlc_skill=true
     local has_repo_adlc_skill=false
+    local has_windows_e2e_runbook=true
 
     if [ -z "$tarball_name" ] || [ ! -f "$pack_dir/$tarball_name" ]; then
         has_tarball=false
@@ -110,6 +111,7 @@ test_npm_pack_includes_runtime_files() {
         has_openai_yaml=false
         has_repo_sdlc_skill=false
         has_repo_adlc_skill=true
+        has_windows_e2e_runbook=false
     else
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "install.sh") ? "yes" : ""')" = "yes" ] || has_install=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "setup.sh") ? "yes" : ""')" = "yes" ] || has_setup=false
@@ -131,6 +133,7 @@ test_npm_pack_includes_runtime_files() {
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "skills/codex-sdlc-wizard/agents/openai.yaml") ? "yes" : ""')" = "yes" ] || has_openai_yaml=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === ".agents/skills/sdlc/SKILL.md") ? "yes" : ""')" = "yes" ] || has_repo_sdlc_skill=false
         [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === ".agents/skills/adlc/SKILL.md") ? "yes" : ""')" = "yes" ] && has_repo_adlc_skill=true
+        [ "$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] && Array.isArray(data[0].files) && data[0].files.some((file) => file.path === "WINDOWS-CODEX-DESKTOP-E2E.md") ? "yes" : ""')" = "yes" ] || has_windows_e2e_runbook=false
     fi
 
     rm -rf "$pack_dir" "$npm_cache"
@@ -149,8 +152,9 @@ test_npm_pack_includes_runtime_files() {
        [ "$has_legacy_sdlc_skill" = "false" ] &&
        [ "$has_openai_yaml" = "true" ] &&
        [ "$has_repo_sdlc_skill" = "true" ] &&
-       [ "$has_repo_adlc_skill" = "false" ]; then
-        pass "npm pack includes the CLI, installer, plugin manifest, and skill runtime files"
+       [ "$has_repo_adlc_skill" = "false" ] &&
+       [ "$has_windows_e2e_runbook" = "true" ]; then
+        pass "npm pack includes the CLI, installer, plugin manifest, skill runtime, and Windows E2E runbook"
     else
         fail "npm pack is missing required runtime files"
     fi

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$SCRIPT_DIR/.."
 README="$REPO_DIR/README.md"
+WINDOWS_E2E_RUNBOOK="$REPO_DIR/WINDOWS-CODEX-DESKTOP-E2E.md"
+GIT_ATTRIBUTES="$REPO_DIR/.gitattributes"
 ROADMAP="$REPO_DIR/ROADMAP.md"
 GOALS_TEMPLATE="$REPO_DIR/templates/GOALS.md.tmpl"
 PACKAGE_JSON="$REPO_DIR/package.json"
@@ -1201,6 +1203,170 @@ test_consumer_bug_report_template_exists() {
     fi
 }
 
+test_windows_desktop_real_install_runbook_exists() {
+    local has_file=true
+    local is_linked=true
+    local identifies_real_install=true
+    local protects_wizard_source=true
+    local preserves_existing_work=true
+    local prefers_plugin=true
+    local keeps_verified_checkout_fallback=true
+    local enforces_lf_shell_checkouts=true
+    local accepts_crlf_gitattributes=true
+    local executes_verified_package=true
+    local executes_verified_plugin_root=true
+    local converts_plugin_root_for_git_bash=true
+    local branches_after_npx_fallback=true
+    local hashes_every_dirty_path=true
+    local hashes_managed_and_installer_targets=true
+    local separates_preservation_from_customized=true
+    local preflights_conflicting_hook_scripts=true
+    local routes_initialized_repos_to_update=true
+    local preflights_bash_on_windows=true
+    local baselines_codex_home_skills=true
+    local redacts_all_report_evidence=true
+    local updates_initialized_verified_fallback=true
+    local enables_available_plugin=true
+    local baselines_legacy_installer_migration=true
+    local preflights_all_hook_collisions_before_fallback=true
+    local requires_hook_approval=true
+    local enforces_minimum_versions=true
+    local distinguishes_git_bash_from_wsl=true
+    local preflights_bash_before_fallback_download=true
+    local preserves_initialized_profile=true
+    local requires_current_plugin_version=true
+    local avoids_hardcoded_release_identity=true
+    local validates_preserved_profile_driver=true
+    local preflights_retired_hook_collisions=true
+    local stops_on_invalid_manifest=true
+    local stops_on_invalid_hooks_document=true
+    local preflights_model_profile_collision=true
+    local fingerprints_exact_candidate_bundle=true
+    local rejects_crlf_shell_payloads=true
+    local canonicalizes_generated_plugin_version=true
+    local retains_verified_package_through_verification=true
+    local reports_verified_package_fallback=true
+    local requires_restart_and_sdlc=true
+    local produces_issue_ready_report=true
+    local avoids_remote_mutation=true
+
+    [ -f "$WINDOWS_E2E_RUNBOOK" ] || has_file=false
+    grep -Fq '[Windows Codex Desktop real-install E2E](WINDOWS-CODEX-DESKTOP-E2E.md)' "$README" || is_linked=false
+    grep -Eqi 'authorized real installation|real product repo' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || identifies_real_install=false
+    grep -Eqi 'stop.*codex-sdlc-wizard.*source repo|codex-sdlc-wizard.*source repo.*stop' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || protects_wizard_source=false
+    grep -Eqi 'preserve.*existing|existing.*preserve' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preserves_existing_work=false
+    grep -Eqi 'Plugins.*(Personal|Installed)|Personal.*Installed' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || prefers_plugin=false
+    grep -Fq 'npm pack "<verified-head-export>"' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || keeps_verified_checkout_fallback=false
+    grep -Fq 'npm pack codex-sdlc-wizard@latest' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null && keeps_verified_checkout_fallback=false
+    [ -f "$GIT_ATTRIBUTES" ] || enforces_lf_shell_checkouts=false
+    grep -Eq '^\*\.sh[[:space:]]+text[[:space:]]+eol=lf[[:space:]]*$' "$GIT_ATTRIBUTES" 2>/dev/null || enforces_lf_shell_checkouts=false
+    printf '%s\r\n' '*.sh text eol=lf' | grep -Eq '^\*\.sh[[:space:]]+text[[:space:]]+eol=lf[[:space:]]*$' || accepts_crlf_gitattributes=false
+    grep -Eqi 'git .*archive.*HEAD|committed HEAD.*(export|archive)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || enforces_lf_shell_checkouts=false
+    grep -Eqi 'verified.*(extracted|package).*(bin[\\/]codex-sdlc-wizard\.js)|(bin[\\/]codex-sdlc-wizard\.js).*(verified|extracted)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || executes_verified_package=false
+    grep -Eq 'npx codex-sdlc-wizard@latest (setup|update|check)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null && executes_verified_package=false
+    grep -Fq 'bash "<verified-plugin-root>/update.sh"' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || executes_verified_plugin_root=false
+    grep -Fq 'bash "<verified-plugin-root>/check.sh"' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || executes_verified_plugin_root=false
+    grep -Fq 'cygpath -u' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || converts_plugin_root_for_git_bash=false
+    grep -Eqi 'npm fallback.*skip.*Phase 3|skip.*Phase 3.*npm fallback' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || branches_after_npx_fallback=false
+    grep -Eqi 'hash every pre-existing (modified|untracked).*path|every pre-existing (modified|untracked).*hash' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || hashes_every_dirty_path=false
+    grep -Eqi 'manifest-managed.*installer-targeted.*regardless of Git status|regardless of Git status.*manifest-managed.*installer-targeted' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || hashes_managed_and_installer_targets=false
+    grep -Eqi 'preserved.*(may|can).*report.*match|customized.*drift.*manifest' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || separates_preservation_from_customized=false
+    grep -Eqi 'uninitialized.*stop.*hook|uninitialized.*(wizard-named|existing).*hook.*stop|stop.*uninitialized.*hook' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preflights_conflicting_hook_scripts=false
+    grep -Eqi 'initialized.*(use|route|run).*update|update.*initialized' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || routes_initialized_repos_to_update=false
+    grep -Eqi 'bash --version|Get-Command bash' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preflights_bash_on_windows=false
+    grep -Eqi 'CODEX_HOME.*(feedback|setup-wizard|update-wizard)|Codex-home.*skill' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || baselines_codex_home_skills=false
+    grep -Eqi 'redact.*(every|all).*(warning|error|transcript|screenshot)|every.*(warning|error|transcript|screenshot).*redact' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || redacts_all_report_evidence=false
+    grep -Eqi 'initialized.*verified.*update|verified.*update.*initialized' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || updates_initialized_verified_fallback=false
+    grep -Eqi '(not installed|disabled|not enabled).*(Install|Enable)|(Install|Enable).*(not installed|disabled|not enabled)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || enables_available_plugin=false
+    grep -Fq 'skills\codex-sdlc-wizard' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || baselines_legacy_installer_migration=false
+    grep -Fq 'skill-backups' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || baselines_legacy_installer_migration=false
+    grep -Eqi 'bash-guard.*git-guard.*session-start.*compact-guard|compact-guard.*session-start.*git-guard.*bash-guard' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preflights_all_hook_collisions_before_fallback=false
+    grep -Eqi '/hooks.*(approved|active)|approved.*active.*hooks' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || requires_hook_approval=false
+    grep -Eqi 'Codex CLI.*0\.144\.0|0\.144\.0.*Codex CLI' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || enforces_minimum_versions=false
+    grep -Eqi 'Node(\.js)?.*18|18.*Node(\.js)?' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || enforces_minimum_versions=false
+    grep -Eqi 'MINGW|MSYS|CYGWIN' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || distinguishes_git_bash_from_wsl=false
+    bash_preflight_line="$(grep -n -m1 'Get-Command bash' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null | cut -d: -f1 || true)"
+    fallback_download_line="$(grep -n -m1 'npm pack "<verified-head-export>" --pack-destination' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null | cut -d: -f1 || true)"
+    if [ -z "$bash_preflight_line" ] || [ -z "$fallback_download_line" ] || [ "$bash_preflight_line" -ge "$fallback_download_line" ]; then
+        preflights_bash_before_fallback_download=false
+    fi
+    grep -Eqi 'initialized.*preserve.*(selected|existing).*profile|(selected|existing).*profile.*preserve.*initialized' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preserves_initialized_profile=false
+    grep -Eqi '(plugin|wizard).*version.*(match|equal).*(package\.json|checkout)|(package\.json|checkout).*version.*(match|equal).*(plugin|wizard)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || requires_current_plugin_version=false
+    grep -Eqi '(stale|older|mismatch).*(npm fallback|stop)|(npm fallback|stop).*(stale|older|mismatch)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || requires_current_plugin_version=false
+    grep -Eq 'matching `[0-9]+\.[0-9]+\.[0-9]+` label' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null && avoids_hardcoded_release_identity=false
+    grep -Eqi 'maximum.*gpt-5\.6-sol.*high|gpt-5\.6-sol.*high.*maximum' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || validates_preserved_profile_driver=false
+    grep -Eqi 'mixed.*gpt-5\.6-terra.*medium|gpt-5\.6-terra.*medium.*mixed' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || validates_preserved_profile_driver=false
+    grep -Fq '.codex/hooks/git-guard.js' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preflights_retired_hook_collisions=false
+    grep -Fq '.codex/hooks/session-start.js' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preflights_retired_hook_collisions=false
+    grep -Eqi 'manifest.*exists.*invalid.*stop|stop.*manifest.*invalid' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || stops_on_invalid_manifest=false
+    grep -Eqi 'hooks\.json.*invalid.*stop|stop.*hooks\.json.*invalid|validate.*hooks\.json.*before.*(setup|mutation)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || stops_on_invalid_hooks_document=false
+    grep -Eqi 'uninitialized.*stop.*model-profile|model-profile.*destructive collision' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || preflights_model_profile_collision=false
+    grep -Eqi '(exact|all).*(hash|fingerprint).*(match|equal)|(match|equal).*(exact|all).*(hash|fingerprint)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || fingerprints_exact_candidate_bundle=false
+    grep -Eqi 'package\.json.*files|files.*package\.json' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || fingerprints_exact_candidate_bundle=false
+    grep -Eqi '(every|complete|all).*(shipped|payload|package).*(file|path)|(shipped|payload|package).*(every|complete|all).*(file|path)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || fingerprints_exact_candidate_bundle=false
+    grep -Eqi 'CRLF.*LF|line endings?.*normaliz|normaliz.*line endings?' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || fingerprints_exact_candidate_bundle=false
+    grep -Eqi '(reject|stop).*(CRLF|carriage return).*\.sh|\.sh.*(CRLF|carriage return).*(reject|stop)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || rejects_crlf_shell_payloads=false
+    grep -Eqi '\.sh.*(raw|unchanged|exact).*bytes|(raw|unchanged|exact).*bytes.*\.sh' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || rejects_crlf_shell_payloads=false
+    grep -Eqi '\+codex.*(canonical|normaliz)|(canonical|normaliz).*\+codex' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || canonicalizes_generated_plugin_version=false
+    grep -Eqi 'keep.*verified package.*(through|until).*Phase 4|verified package.*(through|until).*Phase 4' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || retains_verified_package_through_verification=false
+    grep -Eqi 'restart|fresh.*session' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || requires_restart_and_sdlc=false
+    grep -Fq '$sdlc' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || requires_restart_and_sdlc=false
+    grep -Eqi 'GitHub-issue-ready|issue-ready' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || produces_issue_ready_report=false
+    grep -Eqi 'installation path used:.*verified-package fallback' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || reports_verified_package_fallback=false
+    grep -Eqi 'installation path used:.*npx fallback' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null && reports_verified_package_fallback=false
+    grep -Eqi 'do not commit.*push|do not.*(commit|push|tag|publish)' "$WINDOWS_E2E_RUNBOOK" 2>/dev/null || avoids_remote_mutation=false
+
+    if [ "$has_file" = "true" ] &&
+       [ "$is_linked" = "true" ] &&
+       [ "$identifies_real_install" = "true" ] &&
+       [ "$protects_wizard_source" = "true" ] &&
+       [ "$preserves_existing_work" = "true" ] &&
+       [ "$prefers_plugin" = "true" ] &&
+       [ "$keeps_verified_checkout_fallback" = "true" ] &&
+       [ "$enforces_lf_shell_checkouts" = "true" ] &&
+       [ "$accepts_crlf_gitattributes" = "true" ] &&
+       [ "$executes_verified_package" = "true" ] &&
+       [ "$executes_verified_plugin_root" = "true" ] &&
+       [ "$converts_plugin_root_for_git_bash" = "true" ] &&
+       [ "$branches_after_npx_fallback" = "true" ] &&
+       [ "$hashes_every_dirty_path" = "true" ] &&
+       [ "$hashes_managed_and_installer_targets" = "true" ] &&
+       [ "$separates_preservation_from_customized" = "true" ] &&
+       [ "$preflights_conflicting_hook_scripts" = "true" ] &&
+       [ "$routes_initialized_repos_to_update" = "true" ] &&
+       [ "$preflights_bash_on_windows" = "true" ] &&
+       [ "$baselines_codex_home_skills" = "true" ] &&
+       [ "$redacts_all_report_evidence" = "true" ] &&
+       [ "$updates_initialized_verified_fallback" = "true" ] &&
+       [ "$enables_available_plugin" = "true" ] &&
+       [ "$baselines_legacy_installer_migration" = "true" ] &&
+       [ "$preflights_all_hook_collisions_before_fallback" = "true" ] &&
+       [ "$requires_hook_approval" = "true" ] &&
+       [ "$enforces_minimum_versions" = "true" ] &&
+       [ "$distinguishes_git_bash_from_wsl" = "true" ] &&
+       [ "$preflights_bash_before_fallback_download" = "true" ] &&
+       [ "$preserves_initialized_profile" = "true" ] &&
+       [ "$requires_current_plugin_version" = "true" ] &&
+       [ "$avoids_hardcoded_release_identity" = "true" ] &&
+       [ "$validates_preserved_profile_driver" = "true" ] &&
+       [ "$preflights_retired_hook_collisions" = "true" ] &&
+       [ "$stops_on_invalid_manifest" = "true" ] &&
+       [ "$stops_on_invalid_hooks_document" = "true" ] &&
+       [ "$preflights_model_profile_collision" = "true" ] &&
+       [ "$fingerprints_exact_candidate_bundle" = "true" ] &&
+       [ "$rejects_crlf_shell_payloads" = "true" ] &&
+       [ "$canonicalizes_generated_plugin_version" = "true" ] &&
+       [ "$retains_verified_package_through_verification" = "true" ] &&
+       [ "$reports_verified_package_fallback" = "true" ] &&
+       [ "$requires_restart_and_sdlc" = "true" ] &&
+       [ "$produces_issue_ready_report" = "true" ] &&
+       [ "$avoids_remote_mutation" = "true" ]; then
+        pass "Windows Desktop runbook covers a safe real-repo install and issue-ready E2E report"
+    else
+        fail "Windows Desktop real-install E2E runbook is missing or incomplete"
+    fi
+}
+
 test_installer_smoke_test_clean_project
 test_installer_scaffolds_only_default_repo_scope_sdlc_skill
 test_installer_uses_canonical_sdlc_skill_name
@@ -1238,6 +1404,7 @@ test_readme_has_consumer_parity_sections_without_ecosystem_reveal
 test_readme_documents_official_codex_distribution_status
 test_sponsor_metadata_exists
 test_consumer_bug_report_template_exists
+test_windows_desktop_real_install_runbook_exists
 
 echo ""
 echo "=== Results: $PASSED passed, $FAILED failed ==="


### PR DESCRIPTION
## Summary

- add a safe real-Windows Codex Desktop installation and update E2E runbook
- verify candidate identity, LF-only shell payloads, Git Bash prerequisites, preservation, and invalid-state preflights
- add packaging, npm, and adapter regression coverage plus README discovery guidance

## Validation

- 11/11 proof groups passed
- exact-diff author self-review clean
- independent Sol High review clean
- final Fable High review clean

Refs #79

The issue remains open until the runbook is executed on a real Windows Codex Desktop and CLI installation.