### PR TITLE
docs: make GitHub issues the roadmap source of truth

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,131 +1,34 @@
 # Codex SDLC Wizard Roadmap
 
+## How to use this roadmap
+
+- GitHub issues are the source of truth for scope, acceptance criteria, milestones, and status.
+- The numbered order below is the project priority. The first open item is the next item to work unless `GOALS.md` names a narrower active objective.
+- `GOALS.md`, when present, is the active-scope contract. `ROADMAP.md` is the ordered backlog, not a second implementation plan.
+- When priorities change, reorder links here and update the corresponding GitHub milestones or issue bodies rather than copying their details into this file.
+- Create or deduplicate a GitHub issue before adding an actionable priority here.
+- Completed implementation history belongs in pull requests and GitHub releases, not in an ever-growing roadmap narrative.
+
 ## Current State
 
-- `codex-sdlc-wizard@0.7.34` and `v0.7.34` are the current published release; `0.7.35` is the Desktop-readiness release candidate
-- npm trusted publishing is configured and the GitHub release workflow is now proven for real OIDC publish
-- the repo now ships a skills-only Codex plugin (`.codex-plugin/plugin.json` pointing to `skills/`), one installer skill at `skills/codex-sdlc-wizard/SKILL.md`, and the installer/setup adapter (`install.sh`, `setup.sh`)
-- the plugin declares no MCP servers, apps, or plugin-level hooks; repo-scoped enforcement remains the responsibility of the adaptive installer
-- the npm CLI now defaults to adaptive interactive setup instead of requiring an explicit `setup` subcommand for the main human path
-- setup now layers deterministic scan plus live Codex `gpt-5.6-sol` / `high` refinement when available
-- setup now keeps detected values automatically, asks inferred values conversationally, and asks only missing core repo facts directly
-- the repo-scoped Codex discovery bridge for `$sdlc` is now part of the shipping path
-- consumer-path hardening for auth-heavy boundaries, capability detectors, and docs-strong scaffold repos is shipped
-- honest Codex architecture guidance, confidence/reporting guidance, direct-issue capture, and repo-focus rules are now part of the shipped path
-- the model-profile toggle is now shipped as a user choice:
-  - `mixed`: `gpt-5.6-terra` `medium` main pass + `gpt-5.6-sol` review with an explicit `high` effort override
-  - `maximum`: `gpt-5.6-sol` / `high` throughout
-- researched GPT-5.6 reasoning policy now uses `high` as the consumer and maintainer agentic-coding default, adapts `xhigh` escalation scopes to detected repo risks, and keeps Max/Ultra as explicit escalations instead of defaults
-- setup/install now offer issue-ready feedback for obvious wizard-level failures instead of only failing vaguely
-- install/setup/update now use `maximum` as the standing Sol `high` default; `mixed` is an experimental explicit opt-in that update preserves only when already selected
-- setup/update guidance now treats verification as diagnostic for product failures and stops before editing application code or application tests without explicit user consent
-- setup/update guidance now tells users to exit and reopen Codex after hook/skill repairs, without rerunning setup/update just for that restart
-- install/setup/update now write and repair repo-local `.codex/config.toml` model keys for the selected profile, while preserving unrelated MCP, sandbox, approval, and custom config
-- first-run live setup now defaults to plain `codex` after bootstrap and requires an explicit `full-trust` choice to start that setup handoff with `codex --dangerously-bypass-approvals-and-sandbox`
-- first-run handoff now uses a clearer prompt, recommends model-explicit `codex resume -m ... -c ...` for interrupted handoffs, and avoids the deprecated Windows `shell:true` plus args launcher path
-- first-run live Codex handoff now runs as a managed child process with opt-in timeout cleanup, POSIX signal forwarding, process-group termination, repeated-interrupt handling, and explicit retry/resume guidance
-- setup/install output now prints Codex's canonical full-trust flag (`--dangerously-bypass-approvals-and-sandbox`) for users who normally say yolo-style sessions, while keeping full-trust distinct from historical full-auto wording
-- update guidance now frontloads the npm version boundary: `$update-wizard` repairs repo artifacts, while `npx codex-sdlc-wizard@latest update` consumes the newest package
-- setup guidance now includes Codex Desktop handoff notes for auth-heavy browser/computer-use setup flows
-- generated setup docs and shipped skills now include a task-routing gate that identifies CLI, Desktop/computer-use, browser automation, or human-only lanes before giving execution steps
-- generated setup docs now include a demo runtime claim gate so demo-ready claims must prove the real human-facing runtime, action runner, proof status, live artifact, mutation gates, and not-claimed boundary
-- setup guidance now includes Microsoft 365 auth-lane proof rules for tenant-bound Graph PowerShell and fallback OAuth evidence
-- sponsor metadata is now shipped for GitHub Sponsors and npm funding surfaces
-- the package now treats `$sdlc` as the single canonical public workflow entrypoint, keeps the Codex display name lowercase, and blocks legacy `$codex-sdlc` or imperative `/sdlc` wording from returning
-- setup/install now keep `$sdlc` repo-scoped, install no extra repo-scoped lifecycle skills by default, and install only global helper skills, avoiding same-name global/repo skill collisions
-- repo-root skill installs now keep bundled helper definitions under non-discoverable `SKILL.template.md` names and materialize `SKILL.md` only in intended destinations, preventing recursive duplicate skill discovery
-- setup now detects Playwright MCP browser tooling/profile policy and documents explicit opt-in isolation versus shared persistent auth-heavy flows without rewriting `.mcp.json`
-- setup/update now repair stale platform-specific hook wiring and install universal Node hook entrypoints so a checked-in `.codex/hooks.json` does not flip between macOS Bash and Windows PowerShell commands
-- setup/update now write `[features].hooks = true`, migrate deprecated `[features].codex_hooks` config, and remind users to review pending repo hooks through `/hooks`
-- generated Node hooks now use `.cjs` entrypoints so consumer repos with `"type": "module"` do not break on CommonJS `require`
-- Codex CLI `0.144.0+` is required for GPT-5.6 profiles; its hook surface is recognized, and the wizard intentionally installs `SessionStart`, `PreToolUse`, `PreCompact`, and `PostCompact` while leaving `PermissionRequest`, `PostToolUse`, `UserPromptSubmit`, and `Stop` unwired until a proven SDLC need exists
-- compact lifecycle hooks now preserve SDLC carry-forward context around Codex compaction without blocking normal compaction
-- update now repairs legacy `.js` hook commands and stale `.js` hook manifest entries, including old matching files
-- the git guard is now proof-aware: fresh reviewed SDLC proof allows commit/push, while missing, stale, cross-repo, or mismatched-workdir proof still blocks
-- public install/README/skill copy now keeps unreleased future workflow labels out of handoff text
-- the repo now ships a consumer bug-report template for install/setup/runtime failures
-- the public README now leads with the real `@latest` adaptive setup path and keeps the top section consumer-focused
-- the public README now has consumer-parity sections that explain why to use the wizard without exposing later ecosystem branding
-- the official Codex plugin distribution boundary is documented in README and ROADMAP: ChatGPT Work, the Codex desktop app, and Codex CLI share plugin distribution, while ordinary Chat does not support plugins
-- maintainers can run `node scripts/run-proof-suite.cjs` for bounded parallel release proof without dropping any checks, with `--serial` available for debugging
-- benchmark and pilot-rollout ledgers now exist so model/default-use decisions can be measured, not guessed
-- release, packaging, npm, skill, setup, adapter, update, and E2E tests are green when the parity merge is complete
-- bare `npx codex-sdlc-wizard@latest` now auto-runs the update/check-repair path in already-initialized clones, so cross-machine checkouts sync without remembering separate `check`/`update` commands
-- setup now supports optional `--goals` generation for a manifest-tracked `GOALS.md` active-scope contract, while `ROADMAP.md` remains backlog/history
-- README and generated `GOALS.md` now document manual Codex `/goal` usage as SDLC-backed active work anchored to `$sdlc`, confidence/verification gates, and clean-break commits; programmatic `/goal` automation remains unassumed
-- setup/check now reject unknown arguments before mutating or inspecting the current directory, so mistyped flags do not silently operate on the wrong repo
-- upstream sync has been reviewed through `agentic-ai-sdlc-wizard` / `claude-sdlc-wizard` `v1.73.0`; Codex-relevant workflow hardening was ported, while Claude-only precompact hooks and research churn remain intentionally out of scope unless they prove reusable here
+- Current GitHub release: [`v0.7.35`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.35)
+- Current npm release: [`codex-sdlc-wizard@0.7.35`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.35)
+- Next release milestone: [`0.7.36 — Plugin submission candidate`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/1)
 
-## Next Release Cycle
+## Priority queue
 
-### 0.7.35
-
-Purpose: harden plugin-driven installation before final supported-surface validation and public directory submission.
-
-Scope:
-- preserve unrelated host hooks while replacing only wizard-owned hook entries during install and repair
-- keep successful artifact installation successful when the optional nested Codex handoff cannot start or exits with an ordinary failure
-- refresh manifest hashes only for installer-touched artifacts and preserve untouched customizations
-- distinguish plugin exploration, install/repair, and repo-local lifecycle intents in the picker
-- validate the exact release candidate through Claude-driven black-box Codex Desktop and ChatGPT Work E2E before publishing
-
-## Tracker Cleanup
-
-The `0.7.35` stabilization set is intentionally limited to #55, #56, and the picker-intent fix from #69/PR #70. Issue #66 owns the final supported-surface E2E and public directory submission; remaining docs/research issues stay outside this release lane.
-
-- open a new issue only when pilot consumption exposes another proven reusable wizard bug
-- avoid speculative backlog churn while `0.7.35` is being validated on supported Codex surfaces
-
-## Remaining Backlog
-
-After `0.7.35`, the main backlog is:
-
-- complete supported-surface plugin validation and submit the public directory listing
-- any new reusable wizard fixes discovered during the pilot set
-- model-profile measurement data collection for `mixed` vs `maximum`
-- optional Skill Creator maintenance research after the active backlog stays under control
-
-## Official Codex Plugin Distribution Plan
-
-Official Codex docs make plugins the installable distribution unit for reusable skills, apps, MCP servers, and presentation assets. The implementation outcome for this repo is a skills-only plugin: `.codex-plugin/plugin.json` points to the conventional `skills/` directory and its single installer skill, while npx remains the repo-mutation engine.
-
-- Package the manifest in `codex-sdlc-wizard@0.7.35` so the same artifact carries the plugin skill and the existing CLI/installer.
-- Validate discovery in ChatGPT Work, the Codex desktop app, and Codex CLI. Ordinary Chat remains outside the supported plugin surfaces.
-- Keep MCP servers, apps, and plugin-level hooks out until a proven product need exists; the installer continues to write repo-local hooks and config.
-- The official submission portal is live; the public listing is pending supported-surface validation and submission.
-- Do not imply official OpenAI endorsement unless the plugin is actually accepted into the official Plugin Directory.
-
-## Working Order
-
-1. Validate the skills-only plugin in ChatGPT Work, the Codex desktop app, and Codex CLI
-2. Publish the version-aligned npm package and verify clean installation
-3. Submit the public listing through the live submission portal after supported-surface validation
-4. Keep pilot rollout and stabilization patches tied to real consumption bugs
-
-## Default-Use Gate
-
-Before calling this the default Codex SDLC path, prove it on real pilot repos instead of just repo-self-tests.
-
-- run released builds on 3-5 pilot repos before broadening the default-use claim
-- require pilot success >= 95% before default use
-- allow no more than 1 reusable wizard bug across the pilot set
-- track the pilot set in `benchmarks/pilot-rollout.csv`
-- summarize the gate with `bash scripts/summarize-pilot-rollout.sh`
-
-## Later Research
-
-The creator-tool investigation is complete for the distribution decision: `Plugin Creator` established the minimum valid package shape and led to the implemented skills-only plugin. `Skill Creator` remains a possible later maintenance aid rather than a release blocker.
-
-- investigate programmatic `/goal` automation only if Codex exposes a stable CLI/API path; keep manual `/goal` guidance anchored to `$sdlc`
-- evaluate `Skill Creator` later as a possible aid for skill-structure maintenance
-- keep the implemented `Plugin Creator` manifest contract covered by packaging tests
-- run an experimental explicit opt-in measurement of `gpt-5.6-terra` `medium` for the main working pass with a `gpt-5.6-sol` review explicitly overridden to `high`, and compare that against the Sol `high` `maximum` profile
-- keep an easy toggle between the two explicit profiles:
-  - `mixed`: `gpt-5.6-terra` `medium` main pass plus `gpt-5.6-sol` review with an explicit `high` effort override
-  - `maximum`: `gpt-5.6-sol` / `high` for the whole slice
-- require a sample of 20 slices before considering whether `mixed` should stop being experimental and become a normal-work recommendation
-- numeric target for recommending the mixed mode: at least 95% end-to-end success, follow-up rate <= 10%, and at least a 15% improvement in cycle time versus `maximum`
-- separately measure Sol `high` vs Sol `xhigh` to validate task-scoped escalation triggers while keeping this repo's standing Sol `high` baseline
-- keep Max as a single-task reasoning escalation and Ultra as a subagent-backed parallel-work escalation; most tasks do not need Max or Ultra, and neither becomes a default wizard profile without separate evidence
-- escalate abstract, complex, security-sensitive, or high-blast-radius slices to `xhigh` when `high` leaves unresolved risk; do not make every consumer task pay that cost
-- keep this behind the active workload so it does not compete with the active pilot-rollout and stabilization backlog
+1. **Accept the real Windows candidate** — [#79: Run the plugin submission candidate on real Windows Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79).
+2. **Restore unattended linked-worktree completion** — [#85: Allow proof-bound Git actions in same-repository linked worktrees](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/85).
+3. **Stop redundant reviewer test reruns** — [#73: Use proof-aware prompt-only native Codex review](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/73).
+4. **Timebox one cumulative upstream audit** — [#65: Audit upstream v1.74.0 through v1.90.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65) together with [#81: Extend the audit through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/81).
+5. **Reconcile the older handoff prototype** — [#67: Prototype handoff for hook merge, install consistency, cross-vendor review, and release drift](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/67).
+6. **Codify known-good upgrade stability** — [#84: Adopt a preserve-known-good stability contract](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/84).
+7. **Publish and verify `0.7.36`** — [#88: Publish and verify codex-sdlc-wizard 0.7.36](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88).
+8. **Submit only the verified release** — [#66: Submit Codex SDLC Wizard to the universal Plugins Directory](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66).
+9. **Land dual-review hardening after the submission candidate** — [#64: Use `claude --print` as the cross-model reviewer](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/64) (`0.7.37`).
+10. **Prototype the optional orchestration lane** — [#72: Benchmark Sol High orchestration with Luna Max implementation subagents](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (`0.8.0`).
+11. **Add one read-only health entrypoint** — [#82: Add a Codex-native doctor flow](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82).
+12. **Measure maintainer reasoning effort** — [#86: Benchmark Sol high against the former xhigh maintainer exception](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/86).
+13. **Evaluate Fable before planning** — [#71: Evaluate Fable as an optional planning advisor](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/71).
+14. **Research context-pressure policy** — [#77: Research compaction thresholds and Luna subagent effects](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/77).
+15. **Revisit convergence only after the host adapters stabilize** — [#58: Evaluate portable SDLC MCP versus per-host skills](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/58).

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -2815,6 +2815,7 @@ test_repo_defaults_consumer_and_maintainer_work_to_sol_high() {
     fi
 
     if grep -R -E --exclude-dir=.git --exclude-dir=node_modules --exclude=test-adapter.sh \
+        --exclude=WINDOWS-E2E-FINDINGS-20260804.md \
         'gpt-5\.(5|4|3)|GPT-5\.(5|4|3)|Codex Spark|mini-only' "$REPO_DIR" >/dev/null 2>&1; then
         fail "repo still contains stale legacy model-family references"
         all_passed=false

--- a/tests/test-roadmap.sh
+++ b/tests/test-roadmap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Roadmap tests — keep the repo's next release/issue sequence explicit
+# Roadmap tests — keep GitHub as source of truth and list work in priority order.
 
 set -euo pipefail
 
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$SCRIPT_DIR/.."
 ROADMAP="$REPO_DIR/ROADMAP.md"
 PACKAGE_JSON="$REPO_DIR/package.json"
+REPOSITORY_URL="https://github.com/BaseInfinity/codex-sdlc-wizard"
 PASSED=0
 FAILED=0
 
@@ -24,6 +25,11 @@ fail() {
     FAILED=$((FAILED + 1))
 }
 
+issue_line() {
+    local issue_number="$1"
+    grep -nF "$REPOSITORY_URL/issues/$issue_number" "$ROADMAP" | cut -d: -f1 | head -n1 || true
+}
+
 echo "=== Roadmap Tests ==="
 echo ""
 
@@ -35,283 +41,128 @@ test_roadmap_exists() {
     fi
 }
 
-test_roadmap_states_current_release_status() {
+test_roadmap_declares_order_as_priority() {
+    local has_source_of_truth=true
+    local has_priority_contract=true
+    local has_goals_boundary=true
+
+    grep -Eqi 'GitHub issues.*source of truth|source of truth.*GitHub issues' "$ROADMAP" || has_source_of_truth=false
+    grep -Eqi 'order.*priority|top.*next' "$ROADMAP" || has_priority_contract=false
+    grep -Eqi 'GOALS\.md.*active|active.*GOALS\.md' "$ROADMAP" || has_goals_boundary=false
+
+    if [ "$has_source_of_truth" = "true" ] &&
+       [ "$has_priority_contract" = "true" ] &&
+       [ "$has_goals_boundary" = "true" ]; then
+        pass "Roadmap declares its GitHub-backed priority contract"
+    else
+        fail "Roadmap does not clearly define source of truth, priority order, and active-goal boundaries"
+    fi
+}
+
+test_roadmap_states_current_release() {
     local package_version
-    local has_heading=true
-    local has_current_release=true
-    local has_trusted_publishing=true
-    local current_state_section
+    package_version=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' "$PACKAGE_JSON" | head -n1)
 
-    package_version=$(sed -n 's/.*"version": "\(.*\)".*/\1/p' "$PACKAGE_JSON" | head -n1)
-
-    current_state_section=$(awk '
-        /^## Current State$/ { in_section=1; next }
-        /^## / && in_section { exit }
-        in_section { print }
-    ' "$ROADMAP")
-
-    grep -q '^## Current State$' "$ROADMAP" || has_heading=false
-    echo "$current_state_section" | grep -Eq "${package_version}|v${package_version}" || has_current_release=false
-    echo "$current_state_section" | grep -qi 'trusted publishing' || has_trusted_publishing=false
-
-    if [ "$has_heading" = "true" ] &&
-       [ "$has_current_release" = "true" ] &&
-       [ "$has_trusted_publishing" = "true" ]; then
-        pass "Roadmap captures the current shipped release and publish path"
+    if grep -Eq "GitHub release.*${package_version}|${package_version}.*GitHub release" "$ROADMAP" &&
+       grep -Eq "npm.*${package_version}|${package_version}.*npm" "$ROADMAP"; then
+        pass "Roadmap states the package-aligned current release"
     else
-        fail "Roadmap does not capture the current shipped release state"
+        fail "Roadmap does not state the package-aligned GitHub and npm release"
     fi
 }
 
-test_roadmap_lists_next_release_cycle() {
-    local has_semver_heading=true
-    local has_heading=true
-    local has_supported_surface_gate=true
-    local has_stabilization_rule=true
-    local next_release_section
-    local next_release_heading
+test_roadmap_links_every_open_issue() {
+    local issue_number
+    local missing=0
+    local post_merge_open_issues="58 64 65 66 67 71 72 73 77 79 81 82 84 85 86 88"
 
-    next_release_section=$(awk '
-        /^## Next Release Cycle$/ { in_section=1; next }
-        /^## / && in_section { exit }
-        in_section { print }
-    ' "$ROADMAP")
-    next_release_heading=$(echo "$next_release_section" | awk '/^### / { print $2; exit }')
+    for issue_number in $post_merge_open_issues; do
+        if ! grep -Fq "$REPOSITORY_URL/issues/$issue_number" "$ROADMAP"; then
+            echo "Missing issue link: #$issue_number"
+            missing=$((missing + 1))
+        fi
+    done
 
-    grep -q '^## Next Release Cycle$' "$ROADMAP" || has_heading=false
-    echo "$next_release_heading" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || has_semver_heading=false
-    echo "$next_release_section" | grep -Eqi 'supported-surface|Codex Desktop|ChatGPT Work|black-box' || has_supported_surface_gate=false
-    echo "$next_release_section" | grep -Eqi 'harden|reusable wizard bug|stabiliz|only if pilots surface' || has_stabilization_rule=false
-
-    if [ "$has_heading" = "true" ] &&
-       [ "$has_semver_heading" = "true" ] &&
-       [ "$has_supported_surface_gate" = "true" ] &&
-       [ "$has_stabilization_rule" = "true" ]; then
-        pass "Roadmap lists the next release proof and main engineering item"
+    if [ "$missing" -eq 0 ]; then
+        pass "Roadmap links every GitHub issue that remains open after this change"
     else
-        fail "Roadmap does not list the next release sequence clearly"
+        fail "Roadmap is missing $missing open issue link(s)"
     fi
 }
 
-test_roadmap_records_stabilization_scope() {
-    local has_heading=true
-    local has_release_scope=true
-    local has_e2e_owner=true
-    local has_new_issue_rule=true
-    local avoids_active_issue_refs=true
-    local cleanup_section
+test_roadmap_top_order_matches_release_priority() {
+    local previous=0
+    local current
+    local issue_number
+    local ordered_issues="79 85 73 65 67 84 88 66"
 
-    cleanup_section=$(awk '
-        /^## Tracker Cleanup$/ { in_section=1; next }
-        /^## / && in_section { exit }
-        in_section { print }
-    ' "$ROADMAP")
+    for issue_number in $ordered_issues; do
+        current=$(issue_line "$issue_number")
+        if [ -z "$current" ] || [ "$current" -le "$previous" ]; then
+            fail "Roadmap priority order is wrong at issue #$issue_number"
+            return
+        fi
+        previous="$current"
+    done
 
-    grep -q '^## Tracker Cleanup$' "$ROADMAP" || has_heading=false
-    echo "$cleanup_section" | grep -Eq '#55.*#56.*#69.*#70' || has_release_scope=false
-    echo "$cleanup_section" | grep -Eqi '#66.*(E2E|supported-surface)' || has_e2e_owner=false
-    echo "$cleanup_section" | grep -Eqi 'open a new issue|pilot consumption exposes' || has_new_issue_rule=false
-    echo "$cleanup_section" | grep -Eq '#15|#16|#17|#21|#22' && avoids_active_issue_refs=false
+    pass "Roadmap orders the 0.7.36 release queue by priority"
+}
 
-    if [ "$has_heading" = "true" ] &&
-       [ "$has_release_scope" = "true" ] &&
-       [ "$has_e2e_owner" = "true" ] &&
-       [ "$has_new_issue_rule" = "true" ] &&
-       [ "$avoids_active_issue_refs" = "true" ]; then
-        pass "Roadmap records the bounded stabilization scope and E2E owner"
+test_roadmap_keeps_upstream_issues_together() {
+    local line_65
+    local line_81
+
+    line_65=$(issue_line 65)
+    line_81=$(issue_line 81)
+
+    if [ -n "$line_65" ] && [ "$line_65" = "$line_81" ]; then
+        pass "Roadmap consolidates the cumulative upstream audit links"
     else
-        fail "Roadmap does not record the bounded stabilization scope and E2E owner"
+        fail "Roadmap does not keep issues #65 and #81 in one timeboxed priority item"
     fi
 }
 
-test_roadmap_records_creator_investigation_outcome() {
-    local has_skill_creator=true
-    local has_plugin_creator=true
-    local has_implementation_outcome=true
+test_roadmap_requires_issue_owner_for_every_priority() {
+    local missing_owner=0
+    local line
 
-    grep -qi 'Skill Creator' "$ROADMAP" || has_skill_creator=false
-    grep -qi 'Plugin Creator' "$ROADMAP" || has_plugin_creator=false
-    grep -Eqi 'skills-only plugin|plugin manifest.*implemented|implemented.*plugin manifest' "$ROADMAP" || has_implementation_outcome=false
+    while IFS= read -r line; do
+        if ! grep -Eq "$REPOSITORY_URL/issues/[0-9]+" <<<"$line"; then
+            echo "Priority item has no GitHub issue: $line"
+            missing_owner=$((missing_owner + 1))
+        fi
+    done < <(grep -E '^[0-9]+\. ' "$ROADMAP")
 
-    if [ "$has_skill_creator" = "true" ] &&
-       [ "$has_plugin_creator" = "true" ] &&
-       [ "$has_implementation_outcome" = "true" ]; then
-        pass "Roadmap records the Skill Creator / Plugin Creator investigation outcome"
+    if [ "$missing_owner" -eq 0 ]; then
+        pass "Every roadmap priority has a GitHub issue owner"
     else
-        fail "Roadmap does not record the creator-tool investigation outcome"
+        fail "Roadmap has $missing_owner priority item(s) without a GitHub issue owner"
     fi
 }
 
-test_roadmap_tracks_goal_mode_guidance() {
-    local has_goal_command=true
-    local has_sdlc_anchor=true
-    local has_manual_guidance=true
-    local keeps_automation_future=true
-    local goal_lines
+test_roadmap_removes_stale_prose_sections() {
+    local stale=false
 
-    goal_lines=$(grep -F '/goal' "$ROADMAP" 2>/dev/null || true)
-    [ -n "$goal_lines" ] || has_goal_command=false
-    echo "$goal_lines" | grep -Fq '$sdlc' || has_sdlc_anchor=false
-    echo "$goal_lines" | grep -Eqi 'manual|guidance|SDLC-backed' || has_manual_guidance=false
-    echo "$goal_lines" | grep -Eqi 'programmatic|automation|unassumed|not assume' || keeps_automation_future=false
+    grep -q '^## Tracker Cleanup$' "$ROADMAP" && stale=true
+    grep -q '^## Remaining Backlog$' "$ROADMAP" && stale=true
+    grep -q '^## Working Order$' "$ROADMAP" && stale=true
+    grep -q '^## Later Research$' "$ROADMAP" && stale=true
 
-    if [ "$has_goal_command" = "true" ] &&
-       [ "$has_sdlc_anchor" = "true" ] &&
-       [ "$has_manual_guidance" = "true" ] &&
-       [ "$keeps_automation_future" = "true" ]; then
-        pass "Roadmap tracks manual /goal guidance as SDLC-backed work and keeps automation unassumed"
+    if [ "$stale" = "false" ]; then
+        pass "Roadmap removes duplicated historical and priority prose"
     else
-        fail "Roadmap does not track SDLC-backed /goal guidance clearly enough"
-    fi
-}
-
-test_roadmap_tracks_official_codex_plugin_distribution_plan() {
-    local has_official_distribution=true
-    local has_plugin_manifest=true
-    local has_skills_only_shape=true
-    local has_supported_surfaces=true
-    local has_publish_boundary=true
-    local has_no_endorsement_rule=true
-
-    grep -Eqi 'official Codex.*distribution|Codex plugin distribution' "$ROADMAP" || has_official_distribution=false
-    grep -q '.codex-plugin/plugin.json' "$ROADMAP" || has_plugin_manifest=false
-    grep -Eqi 'skills-only plugin|manifest.*SKILL.md|SKILL.md.*manifest' "$ROADMAP" || has_skills_only_shape=false
-    grep -q 'ChatGPT Work' "$ROADMAP" || has_supported_surfaces=false
-    grep -Eqi 'Codex (desktop|app)' "$ROADMAP" || has_supported_surfaces=false
-    grep -q 'Codex CLI' "$ROADMAP" || has_supported_surfaces=false
-    grep -Eqi 'submission portal.*(live|available|open)|public listing.*pending' "$ROADMAP" || has_publish_boundary=false
-    grep -Eqi 'do not imply official OpenAI endorsement|no official OpenAI endorsement|without official OpenAI endorsement' "$ROADMAP" || has_no_endorsement_rule=false
-
-    if [ "$has_official_distribution" = "true" ] &&
-       [ "$has_plugin_manifest" = "true" ] &&
-       [ "$has_skills_only_shape" = "true" ] &&
-       [ "$has_supported_surfaces" = "true" ] &&
-       [ "$has_publish_boundary" = "true" ] &&
-       [ "$has_no_endorsement_rule" = "true" ]; then
-        pass "Roadmap tracks the official Codex plugin distribution plan and publish boundary"
-    else
-        fail "Roadmap does not track the official Codex plugin distribution plan and publish boundary"
-    fi
-}
-
-test_roadmap_tracks_review_model_measurement() {
-    local has_terra=true
-    local has_sol=true
-    local has_medium_main=true
-    local has_high_review=true
-    local has_measurement_language=true
-    local has_toggle_language=true
-    local has_experimental_framing=true
-    local has_explicit_opt_in=true
-
-    grep -qi 'gpt-5\.6-terra' "$ROADMAP" || has_terra=false
-    grep -qi 'gpt-5\.6-sol' "$ROADMAP" || has_sol=false
-    grep -Eqi 'terra.{0,20}medium|mixed.{0,40}medium' "$ROADMAP" || has_medium_main=false
-    grep -Eqi 'high review|review.*high|cross-model review.*high' "$ROADMAP" || has_high_review=false
-    grep -Eqi 'measure|measurement|compare|validate|data collection' "$ROADMAP" || has_measurement_language=false
-    grep -Eqi 'toggle|profile|switch between|mixed.*maximum|maximum.*mixed' "$ROADMAP" || has_toggle_language=false
-    grep -Eqi 'experiment|experimental|experimentation' "$ROADMAP" || has_experimental_framing=false
-    grep -Eqi 'explicit opt-in|opt in explicitly|explicitly opt' "$ROADMAP" || has_explicit_opt_in=false
-
-    if [ "$has_terra" = "true" ] &&
-       [ "$has_sol" = "true" ] &&
-       [ "$has_medium_main" = "true" ] &&
-       [ "$has_high_review" = "true" ] &&
-       [ "$has_measurement_language" = "true" ] &&
-       [ "$has_toggle_language" = "true" ] &&
-       [ "$has_experimental_framing" = "true" ] &&
-       [ "$has_explicit_opt_in" = "true" ]; then
-        pass "Roadmap tracks mixed-profile measurement as an explicit experiment"
-    else
-        fail "Roadmap does not frame Terra-medium versus Sol-high measurement as an explicit opt-in experiment"
-    fi
-}
-
-test_roadmap_sets_numeric_model_profile_targets() {
-    local has_sample_size=true
-    local has_success_rate=true
-    local has_speed_delta=true
-    local has_reopen_rate=true
-    local has_complex_xhigh_rule=true
-    local has_high_vs_xhigh_gate=true
-    local defaults_high_baseline=true
-
-    grep -Eqi '20 slices|sample of 20|n=20' "$ROADMAP" || has_sample_size=false
-    grep -Eqi '95%|>= ?95%' "$ROADMAP" || has_success_rate=false
-    grep -Eqi '15% faster|>= ?15%|15% improvement' "$ROADMAP" || has_speed_delta=false
-    grep -Eqi '10% reopen|<= ?10%|follow-up rate <= ?10%' "$ROADMAP" || has_reopen_rate=false
-    grep -Eqi 'abstract|complex|high-blast-radius' "$ROADMAP" || has_complex_xhigh_rule=false
-    grep -Eqi 'Sol `?high`?.*Sol `?xhigh`?|high-vs-xhigh|high vs xhigh|one level lower' "$ROADMAP" || has_high_vs_xhigh_gate=false
-    grep -Eqi 'standing.*Sol `?high`?.*baseline|keep.*Sol `?high`?.*baseline|maintainer.*default.*high' "$ROADMAP" || defaults_high_baseline=false
-
-    if [ "$has_sample_size" = "true" ] &&
-       [ "$has_success_rate" = "true" ] &&
-       [ "$has_speed_delta" = "true" ] &&
-       [ "$has_reopen_rate" = "true" ] &&
-       [ "$has_complex_xhigh_rule" = "true" ] &&
-       [ "$has_high_vs_xhigh_gate" = "true" ] &&
-       [ "$defaults_high_baseline" = "true" ]; then
-        pass "Roadmap sets numeric targets for profile measurement and keeps the maintainer Sol-high baseline"
-    else
-        fail "Roadmap does not set numeric targets for model-profile measurement clearly enough"
-    fi
-}
-
-test_roadmap_tracks_default_use_pilot_gate() {
-    local has_pilot_sample=true
-    local has_success_threshold=true
-    local has_reusable_bug_threshold=true
-    local has_default_use_language=true
-
-    grep -Eqi '3-5 pilot repos|3 to 5 pilot repos|five pilot repos' "$ROADMAP" || has_pilot_sample=false
-    grep -Eqi '>= ?95% pilot success|95% pilot success|pilot success >= ?95%' "$ROADMAP" || has_success_threshold=false
-    grep -Eqi '<=? ?1 reusable wizard bug|no more than 1 reusable wizard bug|1 reusable wizard bug' "$ROADMAP" || has_reusable_bug_threshold=false
-    grep -Eqi 'default use|default rollout|default path' "$ROADMAP" || has_default_use_language=false
-
-    if [ "$has_pilot_sample" = "true" ] &&
-       [ "$has_success_threshold" = "true" ] &&
-       [ "$has_reusable_bug_threshold" = "true" ] &&
-       [ "$has_default_use_language" = "true" ]; then
-        pass "Roadmap tracks a measurable pilot gate before default use"
-    else
-        fail "Roadmap does not track a measurable pilot gate before default use"
-    fi
-}
-
-test_roadmap_prioritizes_plugin_surface_validation() {
-    local order_section
-    local line_plugin_validation
-    local line_public_submission
-
-    order_section=$(awk '
-        /^## Working Order$/ { in_section=1; next }
-        /^## / && in_section { exit }
-        in_section { print }
-    ' "$ROADMAP")
-
-    line_plugin_validation=$(echo "$order_section" | nl -ba | grep -Ei 'plugin.*(ChatGPT Work|Codex desktop|supported surfaces)|supported surfaces.*plugin' | awk '{print $1}' | head -n1)
-    line_public_submission=$(echo "$order_section" | nl -ba | grep -Ei 'public.*(submission|listing)|submission portal' | awk '{print $1}' | head -n1)
-
-    if [ -n "${line_plugin_validation:-}" ] &&
-       [ -n "${line_public_submission:-}" ] &&
-       [ "$line_plugin_validation" -lt "$line_public_submission" ]; then
-        pass "Roadmap prioritizes supported-surface plugin validation before public submission"
-    else
-        fail "Roadmap does not prioritize plugin validation ahead of public submission"
+        fail "Roadmap still contains obsolete prose sections that duplicate GitHub"
     fi
 }
 
 test_roadmap_exists
-test_roadmap_states_current_release_status
-test_roadmap_lists_next_release_cycle
-test_roadmap_records_stabilization_scope
-test_roadmap_records_creator_investigation_outcome
-test_roadmap_tracks_goal_mode_guidance
-test_roadmap_tracks_official_codex_plugin_distribution_plan
-test_roadmap_tracks_review_model_measurement
-test_roadmap_sets_numeric_model_profile_targets
-test_roadmap_tracks_default_use_pilot_gate
-test_roadmap_prioritizes_plugin_surface_validation
+test_roadmap_declares_order_as_priority
+test_roadmap_states_current_release
+test_roadmap_links_every_open_issue
+test_roadmap_top_order_matches_release_priority
+test_roadmap_keeps_upstream_issues_together
+test_roadmap_requires_issue_owner_for_every_priority
+test_roadmap_removes_stale_prose_sections
 
 echo ""
 echo "=== Results: $PASSED passed, $FAILED failed ==="


### PR DESCRIPTION
## Summary

- replace duplicated roadmap history with one GitHub-backed priority queue
- align current release and milestone links with the public 0.7.35 state
- require every actionable priority to have a GitHub issue owner
- consolidate cumulative upstream-audit issues and exclude historical Windows evidence from active-model scans
- add #88 for the 0.7.36 publish/verify operation and place #84 in the 0.7.36 milestone

## Verification

- TDD red/green: `bash tests/test-roadmap.sh`
- full proof: `node scripts/run-proof-suite.cjs` — 11/11 groups passed
- exact-diff self-review — clean
- native Codex review with GPT-5.6 Sol High — no actionable regressions
- Fable High final review — `NO ACTIONABLE FINDINGS`

Closes #75