### PR TITLE
fix(windows): require Pester failure exits

### DIFF
--- a/.codex/hooks/git-guard.cjs
+++ b/.codex/hooks/git-guard.cjs
@@ -97,6 +97,9 @@ const UNCONFIGURED_PROOF_COMMANDS = new Set([
   "-",
   "--",
 ]);
+const MAX_RECURSION_DEPTH = 20;
+const SHELL_NAMES = new Set(["bash", "dash", "fish", "ksh", "sh", "zsh"]);
+const WINDOWS_SHELL_NAMES = new Set(["cmd", "powershell", "pwsh"]);
 
 if (process.argv[2] === "prove") {
   process.exit(runProofCli(process.argv.slice(3)));
@@ -115,9 +118,6 @@ if (input.trim() !== "") {
 
 const command = String(payload?.tool_input?.command ?? payload?.command ?? "");
 const commandCwd = commandWorkingDirectory(payload);
-const MAX_RECURSION_DEPTH = 20;
-const SHELL_NAMES = new Set(["bash", "dash", "fish", "ksh", "sh", "zsh"]);
-const WINDOWS_SHELL_NAMES = new Set(["cmd", "powershell", "pwsh"]);
 
 function block(reason) {
   process.stdout.write(JSON.stringify({ decision: "block", reason }));
@@ -239,23 +239,176 @@ function isPowerShellShapedCommand(command) {
   return /^(?:&\s*)?[A-Za-z]+-[A-Za-z][A-Za-z0-9-]*(?:\s|$)/.test(command.trim());
 }
 
-function runPowerShellProofCommand(command, root) {
-  for (const host of ["pwsh", "powershell.exe"]) {
-    const result = childProcess.spawnSync(host, ["-NoProfile", "-Command", command], {
-      cwd: root,
-      stdio: "inherit",
-    });
-    if (result.error?.code === "ENOENT") {
-      continue;
-    }
-    return { ...result, host };
+function isPowerShellHostExecutable(word) {
+  const name = String(word ?? "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    .replace(/\.(?:exe|cmd)$/i, "")
+    .toLowerCase();
+  return new Set(["pwsh", "pwsh-preview", "powershell", "powershell-preview"]).has(name);
+}
+
+function normalizeWindowsPowerShellHostPaths(commandText) {
+  const hostName = String.raw`(?:pwsh(?:-preview)?|powershell(?:-preview)?)`;
+  const quotedPath = new RegExp(
+    String.raw`(^|[\s;&|()])"(?:[A-Za-z]:[\\/]|\\\\)[^"]*[\\/](${hostName})\.(exe|cmd)"`,
+    "gi",
+  );
+  const unquotedPath = new RegExp(
+    String.raw`(^|[\s;&|()])(?:[A-Za-z]:[\\/]|\\\\)[^\s;&|()'"]*[\\/](${hostName})\.(exe|cmd)`,
+    "gi",
+  );
+  const replacePath = (_match, prefix, host, extension) => `${prefix}${host}.${extension}`;
+
+  return String(commandText ?? "")
+    .replace(quotedPath, replacePath)
+    .replace(unquotedPath, replacePath);
+}
+
+function isShellCommandLookup(words) {
+  const commandIndex = words.findIndex((word) => executableName(word) === "command");
+  return commandIndex >= 0 && new Set(["-v", "-V"]).has(words[commandIndex + 1]);
+}
+
+function commandInvokesPowerShellHost(commandText, depth = 0) {
+  if (depth > 5) return true;
+
+  const normalizedCommand = normalizeWindowsPowerShellHostPaths(decodeCmdCaretEscapes(commandText));
+
+  for (const stdinPayload of shellStdinPayloads(normalizedCommand)) {
+    if (commandInvokesPowerShellHost(stdinPayload, depth + 1)) return true;
   }
 
+  for (const words of commandSegments(shellTokens(normalizedCommand))) {
+    if (isShellCommandLookup(words)) continue;
+    const executableIndex = prefixedExecutableIndex(words);
+    if (executableIndex < 0) continue;
+    if (isPowerShellHostExecutable(words[executableIndex])) return true;
+
+    const envPayload = envSplitStringPayload(words);
+    if (envPayload !== null && commandInvokesPowerShellHost(envPayload, depth + 1)) return true;
+
+    const evaluatedPayload = evalPayload(words);
+    if (evaluatedPayload !== null && commandInvokesPowerShellHost(evaluatedPayload, depth + 1)) return true;
+
+    const shellPayload = shellCommandPayload(words);
+    if (shellPayload !== null && commandInvokesPowerShellHost(shellPayload, depth + 1)) return true;
+
+    for (const helperPayload of helperCommandPayloads(words)) {
+      if (commandInvokesPowerShellHost(helperPayload, depth + 1)) return true;
+    }
+
+    if (executableName(words[executableIndex]) === "cmd") {
+      const cmdPayload = cmdShellPayload(words, executableIndex + 1);
+      if (cmdPayload !== null && commandInvokesPowerShellHost(decodeCmdCaretEscapes(cmdPayload), depth + 1)) return true;
+    }
+  }
+
+  return false;
+}
+
+function decodeCmdCaretEscapes(commandText) {
+  return String(commandText ?? "").replace(/\^(?:\r\n|\n|\r|.)/g, (escaped) => {
+    if (escaped === "^\r\n" || escaped === "^\n" || escaped === "^\r") return "";
+    return escaped.slice(1);
+  });
+}
+
+function powerShellProofValidator() {
+  return String.raw`
+using namespace System.Management.Automation.Language
+
+function Stop-UnsafeProof([string]$Message) {
+  [Console]::Error.WriteLine($Message)
+  exit 2
+}
+
+function Test-ProofScript([string]$Source) {
+  $tokens = $null
+  $parseErrors = $null
+  $ast = [Parser]::ParseInput($Source, [ref]$tokens, [ref]$parseErrors)
+  if ($parseErrors.Count -gt 0) {
+    Stop-UnsafeProof ('Unsafe PowerShell proof command: ' + $parseErrors[0].Message)
+  }
+
+  $backgroundPipelines = $ast.FindAll({
+    param($Node)
+    $property = $Node.PSObject.Properties['Background']
+    $null -ne $property -and $property.Value -eq $true
+  }, $true)
+  if ($backgroundPipelines.Count -gt 0) {
+    Stop-UnsafeProof 'Unsafe PowerShell proof command: background pipelines are not allowed in reviewed proof commands.'
+  }
+
+  $commands = $ast.FindAll({ param($Node) $Node -is [CommandAst] }, $true)
+  foreach ($command in $commands) {
+    $name = $command.GetCommandName()
+    if ([string]::IsNullOrWhiteSpace($name)) {
+      $firstElement = @($command.CommandElements)[0]
+      if ($firstElement -is [ScriptBlockExpressionAst]) {
+        continue
+      }
+      Stop-UnsafeProof 'Unsafe PowerShell proof command: dynamic command invocation is not allowed.'
+    }
+
+    $leafName = ($name -split '[\\/]')[-1]
+    if ($leafName -in @('Invoke-Expression', 'iex')) {
+      Stop-UnsafeProof 'Unsafe PowerShell proof command: runtime code evaluation is not allowed.'
+    }
+    if ($leafName -in @('Set-Alias', 'New-Alias', 'sal', 'nal')) {
+      Stop-UnsafeProof 'Unsafe PowerShell proof command: alias creation is not allowed in reviewed proof commands.'
+    }
+    if ($leafName -in @('bash', 'dash', 'fish', 'ksh', 'sh', 'zsh', 'cmd', 'cmd.exe', 'Start-Process', 'start', 'saps', 'Start-Job', 'Start-ThreadJob')) {
+      Stop-UnsafeProof 'Unsafe PowerShell proof command: nested shell and process launchers are not allowed in reviewed proof commands.'
+    }
+    if ($leafName -ieq 'Invoke-Pester') {
+      $failureExit = $command.CommandElements |
+        Where-Object { $_ -is [CommandParameterAst] -and $_.ParameterName -in @('EnableExit', 'CI') } |
+        Where-Object { $_.Extent.Text -match '(?i)^-(?:EnableExit|CI)(?::\s*\$?true)?$' } |
+        Select-Object -First 1
+      if ($null -eq $failureExit) {
+        Stop-UnsafeProof 'Unsafe Pester proof command: Invoke-Pester must include a literal -EnableExit or -CI switch; configuration objects and splatted switches are not statically accepted.'
+      }
+    }
+
+    if ($leafName -in @('pwsh', 'pwsh.exe', 'pwsh.cmd', 'powershell', 'powershell.exe', 'powershell.cmd', 'pwsh-preview', 'pwsh-preview.exe', 'pwsh-preview.cmd', 'powershell-preview', 'powershell-preview.exe', 'powershell-preview.cmd')) {
+      Stop-UnsafeProof 'Unsafe PowerShell proof command: Explicit pwsh/powershell wrappers are not allowed; provide the inner command directly.'
+    }
+  }
+}
+
+Test-ProofScript ([Environment]::GetEnvironmentVariable('CODEX_SDLC_PROOF_COMMAND'))
+`;
+}
+
+function runPowerShellHost(args, options) {
+  for (const host of ["pwsh", "powershell.exe"]) {
+    const result = childProcess.spawnSync(host, args, options);
+    if (result.error?.code === "ENOENT") continue;
+    return { ...result, host };
+  }
   return {
     status: null,
     error: new Error("neither pwsh nor powershell.exe is available"),
     host: "",
   };
+}
+
+function validatePowerShellProofCommand(command, root) {
+  return runPowerShellHost(["-NoProfile", "-NonInteractive", "-Command", powerShellProofValidator()], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, CODEX_SDLC_PROOF_COMMAND: command, CODEX_SDLC_VALIDATE_ONLY: "1" },
+  });
+}
+
+function runPowerShellProofCommand(command, root) {
+  const encodedCommand = Buffer.from(command, "utf16le").toString("base64");
+  return runPowerShellHost(["-NoProfile", "-EncodedCommand", encodedCommand], {
+    cwd: root,
+    stdio: "inherit",
+  });
 }
 
 function proofHelp() {
@@ -428,8 +581,25 @@ function runProofCli(args) {
   }
 
   for (const check of checks) {
-    process.stdout.write(`Running SDLC proof check: ${check}\n`);
     const usePowerShell = /powershell/i.test(configured.language) || isPowerShellShapedCommand(check);
+    if (!usePowerShell && commandInvokesPowerShellHost(check)) {
+      process.stderr.write("Unsafe PowerShell proof command: explicit or shell-wrapped PowerShell hosts are not allowed; provide the inner command directly.\n");
+      return 2;
+    }
+
+    if (usePowerShell) {
+      const validation = validatePowerShellProofCommand(check, root);
+      if (validation.error) {
+        process.stderr.write(`Cannot validate PowerShell proof check: ${validation.error.message}\n`);
+        return 1;
+      }
+      if (validation.status !== 0) {
+        process.stderr.write(validation.stderr || "Unsafe PowerShell proof command.\n");
+        return 2;
+      }
+    }
+
+    process.stdout.write(`Running SDLC proof check: ${check}\n`);
     const result = usePowerShell
       ? runPowerShellProofCommand(check, root)
       : childProcess.spawnSync(check, {

--- a/PROVE-IT.md
+++ b/PROVE-IT.md
@@ -61,6 +61,25 @@ If setup has not detected proof commands yet, pass them explicitly:
 node .codex/hooks/git-guard.cjs prove --reviewed --check "npm test"
 ```
 
+For Pester on every platform, include explicit failure propagation with `-EnableExit`
+or Pester 5's `-CI` switch, such as `Invoke-Pester -Path tests -CI`. The proof
+runner refuses an `Invoke-Pester` command without either switch so failed tests
+cannot produce a passing proof stamp through a zero PowerShell process exit. The
+switch must appear literally on `Invoke-Pester`; configuration-object and
+splatted switch forms are intentionally rejected because the proof gate cannot
+verify their runtime contents statically. Alias creation, background jobs, and
+shell-wrapped PowerShell hosts are rejected for the same reason; invoke the
+proof command directly in the proof host.
+
+For a non-PowerShell project that previously stored a wrapper such as
+`pwsh -File tests.ps1`, set `scan.language` in `.codex-sdlc/manifest.json` to
+`"PowerShell"` and store the inner command directly, for example
+`& ./tests.ps1`. Ensure the script
+returns a nonzero process status when any test fails. The language applies to
+every configured proof check, so consolidate a mixed shell/PowerShell set into
+one PowerShell runner and clear the other proof-command fields; the runner must
+fail if any delegated check fails.
+
 The stamp is stored in Git metadata under `codex-sdlc/proof.json`, expires after
 four hours, and is tied to the current worktree content so it does not dirty the
 worktree. Guarded `git -C <path> commit` and `git -C <path> push` commands may

--- a/README.md
+++ b/README.md
@@ -232,6 +232,27 @@ proof command explicitly:
 node .codex/hooks/git-guard.cjs prove --reviewed --check "npm test"
 ```
 
+Every `Invoke-Pester` proof command must explicitly propagate test
+failures with `-EnableExit` or Pester 5's `-CI` switch (for example,
+`Invoke-Pester -Path tests -CI`). The proof runner rejects a Pester command
+without either switch because Pester can otherwise report failed tests while the
+PowerShell process exits successfully. The switch must be literal on the
+`Invoke-Pester` command; configuration objects and splatted parameters are not
+statically accepted, so rewrite those proof commands to use a direct `-CI` or
+`-EnableExit` invocation. Proof commands also cannot define aliases, launch
+background jobs, or wrap PowerShell inside another shell command; invoke the
+checked command directly in the proof host.
+
+If a non-PowerShell project currently uses a wrapper such as
+`pwsh -File tests.ps1`, make the proof configuration explicitly PowerShell and
+store the inner command instead. In `.codex-sdlc/manifest.json`, set
+`scan.language` to `"PowerShell"`, then use a direct command such as
+`& ./tests.ps1`. The script itself must return a nonzero process status when its
+tests fail. Because language selects the proof host for every configured check,
+a mixed shell/PowerShell proof set must be consolidated into one PowerShell
+runner (and the other proof-command fields cleared); that runner must invoke
+each check and return nonzero if any check fails.
+
 The stamp lives in Git metadata under `codex-sdlc/proof.json`, expires after four
 hours, and is tied to the current worktree content, so stale proof blocks again
 instead of dirtying the worktree. A guarded `git -C <path> commit` or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,22 +13,29 @@
 
 - Current GitHub release: [`v0.7.35`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.35)
 - Current npm release: [`codex-sdlc-wizard@0.7.35`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.35)
-- Next release milestone: [`0.7.36 — Plugin submission candidate`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/1)
+- Next release milestone: [`0.7.36 — Windows-stable plugin candidate`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/1)
 
 ## Priority queue
 
-1. **Accept the real Windows candidate** — [#79: Run the plugin submission candidate on real Windows Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79).
-2. **Resolve the remaining Windows cleanup finding** — [#92: Investigate flaky access-denied proof cleanup on Windows](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/92).
-3. **Stop redundant reviewer test reruns** — [#73: Use proof-aware prompt-only native Codex review](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/73).
-4. **Timebox one cumulative upstream audit** — [#65: Audit upstream v1.74.0 through v1.90.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65) together with [#81: Extend the audit through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/81).
-5. **Reconcile the older handoff prototype** — [#67: Prototype handoff for hook merge, install consistency, cross-vendor review, and release drift](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/67).
+1. **Restore the Windows automation baseline** — [#98: Return the Git Bash npm/handoff suite to 25/25 passing](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/98).
+2. **Enforce the chosen Sol High policy everywhere** — [#86: Remove autonomous `xhigh` escalation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/86).
+3. **Make native review proof-aware across every shipped layer** — [#73: Avoid redundant reviewer suite reruns](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/73).
+4. **Resolve nondeterministic Windows proof cleanup** — [#92: Investigate the access-denied proof-stamp race](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/92).
+5. **Keep Windows review evidence honest** — [#93: Detect WindowsApps PowerShell before trusting Codex review validation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/93).
 6. **Codify known-good upgrade stability** — [#84: Adopt a preserve-known-good stability contract](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/84).
-7. **Publish and verify `0.7.36` only after Windows acceptance** — [#88: Publish and verify codex-sdlc-wizard 0.7.36](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88).
-8. **Submit only the Windows-verified public release** — [#66: Submit Codex SDLC Wizard to the universal Plugins Directory](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66).
-9. **Land dual-review hardening after the submission candidate** — [#64: Use `claude --print` as the cross-model reviewer](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/64) (`0.7.37`).
-10. **Prototype the optional orchestration lane** — [#72: Benchmark Sol High orchestration with Luna Max implementation subagents](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (`0.8.0`).
-11. **Add one read-only health entrypoint** — [#82: Add a Codex-native doctor flow](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82).
-12. **Measure maintainer reasoning effort** — [#86: Benchmark Sol high against the former xhigh maintainer exception](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/86).
-13. **Evaluate Fable before planning** — [#71: Evaluate Fable as an optional planning advisor](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/71).
-14. **Research context-pressure policy** — [#77: Research compaction thresholds and Luna subagent effects](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/77).
-15. **Revisit convergence only after the host adapters stabilize** — [#58: Evaluate portable SDLC MCP versus per-host skills](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/58).
+7. **Publish and verify `0.7.36` after the automated release gates pass** — [#88: Publish and verify codex-sdlc-wizard 0.7.36](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88).
+8. **Validate the published release on real Windows** — [#79: Run the released plugin in Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79).
+9. **Land bounded dual-review enforcement** — [#64: Use `claude --print` as the cross-model reviewer](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/64) (`0.7.37`).
+10. **Audit instruction ownership and freshness** — [#95: Audit `AGENTS.md` against current Codex guidance](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/95) (`0.7.37`).
+11. **Make the GitHub lifecycle explicit and enforceable** — [#100: Teach issue-to-PR-to-milestone delivery](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/100) (`0.7.37`).
+12. **Rename the public harness without breaking npm compatibility** — [#101: Rename wizard to harness using the proven migration checklist](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/101) (`0.7.37`).
+13. **Submit only the hardened, Windows-verified public release** — [#66: Submit Codex SDLC Wizard to the universal Plugins Directory](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66).
+14. **Prototype the optional orchestration lane** — [#72: Benchmark Sol High orchestration with bounded Luna implementation work](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (`0.8.0`).
+15. **Add one read-only health entrypoint** — [#82: Add a Codex-native doctor flow](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82).
+16. **Timebox one cumulative upstream audit** — [#65: Audit upstream v1.74.0 through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65).
+17. **Detect public-release drift deterministically** — [#99: Add release-drift detection and issue reconciliation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/99).
+18. **Evaluate Fable before planning** — [#71: Evaluate Fable as an optional planning advisor](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/71).
+19. **Research context-pressure policy** — [#77: Research compaction thresholds and Luna subagent effects](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/77).
+20. **Research a Copilot CLI host adapter** — [#97: Evaluate GitHub Copilot CLI support](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/97).
+21. **Revisit portable enforcement after host adapters stabilize** — [#58: Evaluate portable SDLC MCP versus per-host skills](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/58).
+22. **Consider a Copilot Studio surface only after portable enforcement exists** — [#96: Evaluate a Copilot Studio front end](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/96).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,13 +18,13 @@
 ## Priority queue
 
 1. **Accept the real Windows candidate** — [#79: Run the plugin submission candidate on real Windows Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79).
-2. **Restore unattended linked-worktree completion** — [#85: Allow proof-bound Git actions in same-repository linked worktrees](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/85).
+2. **Resolve the remaining Windows cleanup finding** — [#92: Investigate flaky access-denied proof cleanup on Windows](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/92).
 3. **Stop redundant reviewer test reruns** — [#73: Use proof-aware prompt-only native Codex review](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/73).
 4. **Timebox one cumulative upstream audit** — [#65: Audit upstream v1.74.0 through v1.90.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65) together with [#81: Extend the audit through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/81).
 5. **Reconcile the older handoff prototype** — [#67: Prototype handoff for hook merge, install consistency, cross-vendor review, and release drift](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/67).
 6. **Codify known-good upgrade stability** — [#84: Adopt a preserve-known-good stability contract](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/84).
-7. **Publish and verify `0.7.36`** — [#88: Publish and verify codex-sdlc-wizard 0.7.36](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88).
-8. **Submit only the verified release** — [#66: Submit Codex SDLC Wizard to the universal Plugins Directory](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66).
+7. **Publish and verify `0.7.36` only after Windows acceptance** — [#88: Publish and verify codex-sdlc-wizard 0.7.36](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88).
+8. **Submit only the Windows-verified public release** — [#66: Submit Codex SDLC Wizard to the universal Plugins Directory](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66).
 9. **Land dual-review hardening after the submission candidate** — [#64: Use `claude --print` as the cross-model reviewer](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/64) (`0.7.37`).
 10. **Prototype the optional orchestration lane** — [#72: Benchmark Sol High orchestration with Luna Max implementation subagents](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (`0.8.0`).
 11. **Add one read-only health entrypoint** — [#82: Add a Codex-native doctor flow](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82).

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -137,6 +137,22 @@ deep_nested_eval_command() {
 echo "=== Codex SDLC Adapter Tests ==="
 echo ""
 
+write_fake_pester_module() {
+    local module_root="$1"
+    mkdir -p "$module_root/Pester"
+    cat > "$module_root/Pester/Pester.psm1" <<'EOF'
+function Invoke-Pester {
+    param(
+        [object]$Path,
+        [object]$ExcludeTag,
+        [switch]$EnableExit,
+        [switch]$CI
+    )
+}
+Export-ModuleMember -Function Invoke-Pester
+EOF
+}
+
 if [ "$IS_WINDOWS" = "true" ]; then
     PRETOOL_SCRIPT="$HOOKS_DIR/git-guard.ps1"
     SESSION_SCRIPT="$HOOKS_DIR/session-start.ps1"
@@ -221,8 +237,8 @@ test_universal_proof_runs_powershell_manifest_commands_in_pwsh() {
     cp "$UNIVERSAL_PRETOOL_SCRIPT" "$ws/.codex/hooks/git-guard.cjs"
     cat > "$module_root/Pester/Pester.psm1" <<'EOF'
 function Invoke-Pester {
-    param([string]$Path)
-    Set-Content -LiteralPath $env:CODEX_SDLC_TEST_MARKER -Value "$($PSVersionTable.PSEdition)|$Path"
+    param([string]$Path, [switch]$EnableExit)
+    Set-Content -LiteralPath $env:CODEX_SDLC_TEST_MARKER -Value "$($PSVersionTable.PSEdition)|$Path|$EnableExit"
 }
 Export-ModuleMember -Function Invoke-Pester
 EOF
@@ -230,7 +246,7 @@ EOF
 {
   "scan": {
     "language": "PowerShell",
-    "test_command": "Invoke-Pester -Path tests"
+    "test_command": "Invoke-Pester -Path tests -EnableExit"
   }
 }
 EOF
@@ -246,9 +262,26 @@ EOF
     set -e
 
     [ "$status" -eq 0 ] || valid=false
-    grep -Fxq 'Core|tests' "$marker" 2>/dev/null || valid=false
-    echo "$output" | grep -Fq 'Running SDLC proof check: Invoke-Pester -Path tests' || valid=false
+    grep -Fxq 'Core|tests|True' "$marker" 2>/dev/null || valid=false
+    echo "$output" | grep -Fq 'Running SDLC proof check: Invoke-Pester -Path tests -EnableExit' || valid=false
     echo "$output" | grep -Fq 'Wrote SDLC proof:' || valid=false
+    rm -f "$ws/.git/codex-sdlc/proof.json"
+    cat > "$ws/.codex-sdlc/manifest.json" <<'EOF'
+{
+  "scan": {
+    "language": "PowerShell",
+    "test_command": "Invoke-Pester -Path tests"
+  }
+}
+EOF
+    set +e
+    output=$(cd "$ws" && CODEX_SDLC_TEST_MARKER="$win_marker" PSModulePath="$win_module_root;$PSModulePath" \
+        node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+    status=$?
+    set -e
+    [ "$status" -eq 2 ] || valid=false
+    echo "$output" | grep -Fqi 'Unsafe Pester proof command' || valid=false
+    [ ! -e "$ws/.git/codex-sdlc/proof.json" ] || valid=false
     rm -rf "$ws"
 
     if [ "$valid" = "true" ]; then
@@ -256,6 +289,482 @@ EOF
     else
         printf '%s\n' "$output" >&2
         fail "universal proof sent a PowerShell manifest command to the wrong interpreter"
+    fi
+}
+
+test_universal_proof_rejects_shell_prefixed_powershell_hosts() {
+    local ws fakebin command output status valid=true
+    local -a commands
+    ws=$(mktemp -d)
+    fakebin=$(mktemp -d)
+    mkdir -p "$ws/.codex/hooks" "$ws/.codex-sdlc"
+    cp "$UNIVERSAL_PRETOOL_SCRIPT" "$ws/.codex/hooks/git-guard.cjs"
+    if [ "$IS_WINDOWS" = "true" ]; then
+        cat > "$fakebin/pwsh.cmd" <<'EOF'
+@echo off
+if "%CODEX_SDLC_VALIDATE_ONLY%"=="1" exit /b 2
+echo Tests Passed: 0, Failed: 1 1>&2
+exit /b 0
+EOF
+    else
+        cat > "$fakebin/pwsh" <<'EOF'
+#!/bin/sh
+[ "$CODEX_SDLC_VALIDATE_ONLY" = "1" ] && exit 2
+echo 'Tests Passed: 0, Failed: 1' >&2
+exit 0
+EOF
+        chmod +x "$fakebin/pwsh"
+    fi
+    printf '%s\n' 'proof-target' > "$ws/app.txt"
+    (cd "$ws" && git init -q && git add app.txt)
+
+    commands=(
+        'echo setup && pwsh -Command "Invoke-Pester -Path tests"'
+        'bash -c '\''pwsh -Command "Invoke-Pester -Path tests"'\'''
+        'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -Command "Invoke-Pester -Path tests"'
+        'cmd.exe /c po^wershell.exe -NoProfile -Command "Invoke-Pester -Path tests"'
+        'po^wershell.exe -NoProfile -Command "Invoke-Pester -Path tests"'
+        'eval '\''pwsh -NoProfile -Command "Invoke-Pester -Path tests"'\'''
+        'printf '\''%s\n'\'' '\''pwsh -NoProfile -Command "Invoke-Pester -Path tests"'\'' | sh'
+    )
+    for command in "${commands[@]}"; do
+        TEST_COMMAND="$command" node -e '
+const fs = require("fs");
+fs.writeFileSync(process.argv[1], JSON.stringify({
+  scan: { language: "JavaScript", test_command: process.env.TEST_COMMAND },
+}));
+' "$ws/.codex-sdlc/manifest.json"
+        rm -f "$ws/.git/codex-sdlc/proof.json"
+
+        set +e
+        output=$(cd "$ws" && PATH="$fakebin:$PATH" node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+        status=$?
+        set -e
+
+        if [ "$status" -ne 2 ] || [ -e "$ws/.git/codex-sdlc/proof.json" ]; then
+            printf 'wrapped PowerShell proof was accepted: %s\n%s\n' "$command" "$output" >&2
+            valid=false
+        fi
+    done
+    rm -rf "$ws" "$fakebin"
+
+    if [ "$valid" = "true" ]; then
+        pass "universal proof rejects PowerShell hosts after shell prefixes"
+    else
+        printf '%s\n' "$output" >&2
+        fail "universal proof stamped a shell-prefixed bare Pester command"
+    fi
+}
+
+test_universal_proof_preserves_powershell_names_as_data() {
+    local ws fakebin output status query_output query_status stdin_output stdin_status powershell_output powershell_status valid=true
+    ws=$(mktemp -d)
+    fakebin=$(mktemp -d)
+    mkdir -p "$ws/.codex/hooks" "$ws/.codex-sdlc" "$ws/tests"
+    cp "$UNIVERSAL_PRETOOL_SCRIPT" "$ws/.codex/hooks/git-guard.cjs"
+    cat > "$ws/.codex-sdlc/manifest.json" <<'EOF'
+{
+  "scan": {
+    "language": "JavaScript",
+    "test_command": "printf '%s\\n' powershell pwsh"
+  }
+}
+EOF
+    printf '%s\n' 'proof-target' > "$ws/app.txt"
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$ws/tests/run.sh"
+    (cd "$ws" && git init -q && git add app.txt)
+
+    set +e
+    output=$(cd "$ws" && node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || valid=false
+    echo "$output" | grep -Fq 'powershell' || valid=false
+    echo "$output" | grep -Fq 'pwsh' || valid=false
+    [ -e "$ws/.git/codex-sdlc/proof.json" ] || valid=false
+
+    rm -f "$ws/.git/codex-sdlc/proof.json"
+    cat > "$ws/.codex-sdlc/manifest.json" <<'EOF'
+{
+  "scan": {
+    "language": "PowerShell",
+    "test_command": "'pwsh' | Select-String pwsh"
+  }
+}
+EOF
+    if ! command -v pwsh >/dev/null 2>&1 && ! command -v powershell.exe >/dev/null 2>&1; then
+        printf '%s\n' '#!/bin/sh' 'exit 0' > "$fakebin/pwsh"
+        chmod +x "$fakebin/pwsh"
+    fi
+    set +e
+    powershell_output=$(cd "$ws" && PATH="$fakebin:$PATH" node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+    powershell_status=$?
+    set -e
+    [ "$powershell_status" -eq 0 ] || valid=false
+    echo "$powershell_output" | grep -Fq 'Wrote SDLC proof:' || valid=false
+    [ -e "$ws/.git/codex-sdlc/proof.json" ] || valid=false
+
+    rm -f "$ws/.git/codex-sdlc/proof.json"
+    cat > "$ws/.codex-sdlc/manifest.json" <<'EOF'
+{
+  "scan": {
+    "language": "JavaScript",
+    "test_command": "command -v pwsh >/dev/null || true"
+  }
+}
+EOF
+    set +e
+    query_output=$(cd "$ws" && PATH="$fakebin:$PATH" node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+    query_status=$?
+    set -e
+    [ "$query_status" -eq 0 ] || valid=false
+    echo "$query_output" | grep -Fq 'Wrote SDLC proof:' || valid=false
+    [ -e "$ws/.git/codex-sdlc/proof.json" ] || valid=false
+
+    rm -f "$ws/.git/codex-sdlc/proof.json"
+    cat > "$ws/.codex-sdlc/manifest.json" <<'EOF'
+{
+  "scan": {
+    "language": "JavaScript",
+    "test_command": "bash < tests/run.sh"
+  }
+}
+EOF
+    set +e
+    stdin_output=$(cd "$ws" && node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+    stdin_status=$?
+    set -e
+    [ "$stdin_status" -eq 0 ] || valid=false
+    echo "$stdin_output" | grep -Fq 'Wrote SDLC proof:' || valid=false
+    [ -e "$ws/.git/codex-sdlc/proof.json" ] || valid=false
+    rm -rf "$ws" "$fakebin"
+
+    if [ "$valid" = "true" ]; then
+        pass "universal proof preserves PowerShell host names used only as data"
+    else
+        printf '%s\n' "$output" >&2
+        fail "universal proof misclassified a PowerShell host name used as data"
+    fi
+}
+
+test_universal_proof_rejects_pester_without_exit_propagation() {
+    local ws fakebin command output status valid=true
+    local -a multiline_commands
+    ws=$(mktemp -d)
+    fakebin=$(mktemp -d)
+    mkdir -p "$ws/.codex/hooks" "$ws/.codex-sdlc"
+    cp "$UNIVERSAL_PRETOOL_SCRIPT" "$ws/.codex/hooks/git-guard.cjs"
+    grep -Fq 'Explicit pwsh/powershell wrappers are not allowed' \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    if grep -Fq 'cmd.exe wrappers around PowerShell are not allowed' \
+        "$ws/.codex/hooks/git-guard.cjs"; then
+        valid=false
+    fi
+    grep -Fq "ParameterName -in @('EnableExit', 'CI')" \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq 'Where-Object { $_.Extent.Text -match' \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq "'pwsh-preview'" "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq "'powershell-preview'" "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq 'EncodedCommand' \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq "'Set-Alias', 'New-Alias'" \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq "'bash', 'dash'" \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq "'Start-Job'" \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    grep -Fq "Properties['Background']" \
+        "$ws/.codex/hooks/git-guard.cjs" || valid=false
+    printf '%s\n' 'proof-target' > "$ws/app.txt"
+    (cd "$ws" && git init -q && git add app.txt)
+    if ! command -v pwsh >/dev/null 2>&1 && ! command -v powershell.exe >/dev/null 2>&1; then
+        cat > "$fakebin/pwsh" <<'EOF'
+#!/bin/sh
+if [ "$CODEX_SDLC_VALIDATE_ONLY" = "1" ]; then
+    echo 'Unsafe PowerShell proof command: test validator rejected command.' >&2
+    exit 2
+fi
+exit 0
+EOF
+        chmod +x "$fakebin/pwsh"
+    fi
+
+    while IFS= read -r command; do
+        TEST_COMMAND="$command" node -e '
+const fs = require("fs");
+fs.writeFileSync(process.argv[1], JSON.stringify({
+  scan: { language: "PowerShell", test_command: process.env.TEST_COMMAND },
+}));
+' "$ws/.codex-sdlc/manifest.json"
+        rm -f "$ws/.git/codex-sdlc/proof.json"
+
+        set +e
+        output=$(cd "$ws" && PATH="$fakebin:$PATH" node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+        status=$?
+        set -e
+
+        if [ "$status" -ne 2 ] \
+            || ! echo "$output" | grep -Fqi 'Unsafe' \
+            || [ -e "$ws/.git/codex-sdlc/proof.json" ]; then
+            printf 'unsafe Pester case was accepted: %s\n' "$command" >&2
+            valid=false
+        fi
+    done <<'EOF'
+Invoke-Pester -Path tests
+$result = Invoke-Pester -Path tests
+Invoke-Pester -Path unit; Invoke-Pester -Path integration -EnableExit
+Invoke-Pester -Path tests # TODO: add -EnableExit
+Invoke-Pester -Path tests <# TODO: add -EnableExit #>
+Invoke-Pester -Path tests -Output "Remember -EnableExit next time"
+Invoke-Pester -Path tests -CI:$false
+pwsh -Command "Invoke-Pester -Path tests"
+pwsh -Command Invoke-Pester -Path tests
+pwsh '-Command' 'Invoke-Pester -Path tests'
+pwsh '-c' 'Invoke-Pester -Path tests'
+"pwsh" -Command "Invoke-Pester -Path tests"
+& "pwsh" -Command "Invoke-Pester -Path tests"
+pwsh -EncodedCommand SQBuAHYAbwBrAGUALQBQAGUAcwB0AGUAcgA=
+powershell.exe -EncodedCommand SQBuAHYAbwBrAGUALQBQAGUAcwB0AGUAcgA=
+powershell-preview -Command "Invoke-Pester -Path tests"
+pwsh-preview -Command "Invoke-Pester -Path tests"
+cmd.exe /c powershell.exe -Command "Invoke-Pester -Path tests"
+Write-Output "$(Invoke-Pester -Path tests)"
+& "Invoke-Pester" -Path tests
+Invoke-`Pester -Path tests
+Pester\Invoke-Pester -Path tests
+Write-Output C#; Invoke-Pester -Path tests
+Invoke-Pester -Path (Get-Tests -EnableExit)
+Write-Output "$(if ($true) { Invoke-Pester -Path tests })"
+pwsh -Command 'Write-Output ''setup''; Invoke-Pester -Path tests'
+$p = 'Invoke-Pester'; & $p -Path tests
+. Invoke-Pester -Path tests
+Invoke-Pester -Path tests -ExcludeTag `-EnableExit
+$payload = 'Invoke-Pester -Path tests'; pwsh -Command $payload
+$payload = 'Invoke-Pester -Path tests'; Invoke-Expression $payload
+iex 'Invoke-Pester -Path tests'
+Import-Module Pester; Set-Alias Run-Tests Invoke-Pester; Run-Tests -Path tests
+Start-Process pwsh -ArgumentList '-Command','Invoke-Pester -Path tests'
+Start-Job { Invoke-Pester -Path tests -CI } | Wait-Job | Receive-Job
+Invoke-Pester -Path tests -CI &
+EOF
+
+    multiline_commands=(
+        $'& `\n\'Invoke-Pester\' -Path tests'
+        $'$note = @\'\nit\'s text\n\'@\nInvoke-Pester -Path tests'
+    )
+    for command in "${multiline_commands[@]}"; do
+        TEST_COMMAND="$command" node -e '
+const fs = require("fs");
+fs.writeFileSync(process.argv[1], JSON.stringify({
+  scan: { language: "PowerShell", test_command: process.env.TEST_COMMAND },
+}));
+' "$ws/.codex-sdlc/manifest.json"
+        rm -f "$ws/.git/codex-sdlc/proof.json"
+
+        set +e
+        output=$(cd "$ws" && PATH="$fakebin:$PATH" node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+        status=$?
+        set -e
+
+        if [ "$status" -ne 2 ] \
+            || ! echo "$output" | grep -Fqi 'Unsafe' \
+            || [ -e "$ws/.git/codex-sdlc/proof.json" ]; then
+            printf 'unsafe multiline Pester case was accepted: %s\n' "$command" >&2
+            valid=false
+        fi
+    done
+    rm -rf "$ws" "$fakebin"
+
+    if [ "$valid" = "true" ]; then
+        pass "universal proof rejects Pester commands that can mask failed tests"
+    else
+        printf '%s\n' "$output" >&2
+        fail "universal proof accepted Pester without explicit failed-test exit propagation"
+    fi
+}
+
+test_universal_proof_accepts_pester_switch_after_quoted_separators() {
+    local ws fakebin module_root test_psmodule_path command output status valid=true
+    local -a multiline_commands
+    ws=$(mktemp -d)
+    fakebin=$(mktemp -d)
+    mkdir -p "$ws/.codex/hooks" "$ws/.codex-sdlc"
+    cp "$UNIVERSAL_PRETOOL_SCRIPT" "$ws/.codex/hooks/git-guard.cjs"
+    printf '%s\n' 'proof-target' > "$ws/app.txt"
+    (cd "$ws" && git init -q && git add app.txt)
+    if command -v pwsh >/dev/null 2>&1 || command -v powershell.exe >/dev/null 2>&1; then
+        module_root="$ws/modules"
+        write_fake_pester_module "$module_root"
+        if [ "$IS_WINDOWS" = "true" ]; then
+            test_psmodule_path="$(cygpath -w "$module_root");$PSModulePath"
+        else
+            test_psmodule_path="$module_root${PSModulePath:+:$PSModulePath}"
+        fi
+    else
+        cat > "$fakebin/pwsh" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+        chmod +x "$fakebin/pwsh"
+        test_psmodule_path="${PSModulePath:-}"
+    fi
+
+    while IFS= read -r command; do
+        TEST_COMMAND="$command" node -e '
+const fs = require("fs");
+fs.writeFileSync(process.argv[1], JSON.stringify({
+  scan: { language: "PowerShell", test_command: process.env.TEST_COMMAND },
+}));
+' "$ws/.codex-sdlc/manifest.json"
+        rm -f "$ws/.git/codex-sdlc/proof.json"
+
+        set +e
+        output=$(cd "$ws" && PSModulePath="$test_psmodule_path" PATH="$fakebin:$PATH" \
+            node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+        status=$?
+        set -e
+
+        if [ "$status" -ne 0 ] \
+            || ! echo "$output" | grep -Fq 'Wrote SDLC proof:' \
+            || [ ! -e "$ws/.git/codex-sdlc/proof.json" ]; then
+            printf 'safe Pester case was rejected: %s\n%s\n' "$command" "$output" >&2
+            valid=false
+        fi
+    done <<'EOF'
+Invoke-Pester -Path "C:\R&D\tests" -EnableExit
+Invoke-Pester -Path 'C:\R|D\tests' -EnableExit
+(Invoke-Pester -Path tests -EnableExit)
+Invoke-Pester -Path 'Invoke-Pester.Tests.ps1' -EnableExit
+Pester\Invoke-Pester -Path tests -EnableExit
+Invoke-Pester -Path tests -CI
+Invoke-Pester -Path tests -CI:$false -EnableExit
+Write-Output Invoke-Pester
+Write-Output '$(Invoke-Pester -Path tests)'
+Write-Output "$(Invoke-Pester -Path (Join-Path . tests) -EnableExit)"
+Write-Output "literal `$(Invoke-Pester -Path tests)"; Invoke-Pester -Path tests -EnableExit
+& { Invoke-Pester -Path tests -EnableExit }
+EOF
+
+    multiline_commands=(
+        $'Invoke-Pester -Path tests `\n -EnableExit'
+    )
+    for command in "${multiline_commands[@]}"; do
+        TEST_COMMAND="$command" node -e '
+const fs = require("fs");
+fs.writeFileSync(process.argv[1], JSON.stringify({
+  scan: { language: "PowerShell", test_command: process.env.TEST_COMMAND },
+}));
+' "$ws/.codex-sdlc/manifest.json"
+        rm -f "$ws/.git/codex-sdlc/proof.json"
+
+        set +e
+        output=$(cd "$ws" && PSModulePath="$test_psmodule_path" PATH="$fakebin:$PATH" \
+            node .codex/hooks/git-guard.cjs prove --reviewed 2>&1)
+        status=$?
+        set -e
+
+        if [ "$status" -ne 0 ] \
+            || ! echo "$output" | grep -Fq 'Wrote SDLC proof:' \
+            || [ ! -e "$ws/.git/codex-sdlc/proof.json" ]; then
+            printf 'safe multiline Pester case was rejected: %s\n%s\n' "$command" "$output" >&2
+            valid=false
+        fi
+    done
+    rm -rf "$ws" "$fakebin"
+
+    if [ "$valid" = "true" ]; then
+        pass "universal proof accepts Pester failure propagation after quoted separators"
+    else
+        printf '%s\n' "$output" >&2
+        fail "universal proof rejected a valid Pester command containing quoted separators"
+    fi
+}
+
+test_universal_proof_validates_explicit_powershell_host_wrappers() {
+    local ws fakebin output status valid=true
+    ws=$(mktemp -d)
+    fakebin=$(mktemp -d)
+    mkdir -p "$ws/.codex/hooks"
+    cp "$UNIVERSAL_PRETOOL_SCRIPT" "$ws/.codex/hooks/git-guard.cjs"
+    printf '%s\n' 'proof-target' > "$ws/app.txt"
+    (cd "$ws" && git init -q && git add app.txt)
+    if ! command -v pwsh >/dev/null 2>&1 && ! command -v powershell.exe >/dev/null 2>&1; then
+        cat > "$fakebin/pwsh" <<'EOF'
+#!/bin/sh
+if [ "$CODEX_SDLC_VALIDATE_ONLY" = "1" ]; then
+    echo 'Unsafe Pester proof command: test validator rejected command.' >&2
+    exit 2
+fi
+exit 0
+EOF
+        chmod +x "$fakebin/pwsh"
+    fi
+
+    set +e
+    output=$(cd "$ws" && PATH="$fakebin:$PATH" node .codex/hooks/git-guard.cjs prove --reviewed \
+        --check 'pwsh -Command "Invoke-Pester -Path tests"' 2>&1)
+    status=$?
+    set -e
+
+    [ "$status" -eq 2 ] || valid=false
+    echo "$output" | grep -Fqi 'Unsafe' || valid=false
+    [ ! -e "$ws/.git/codex-sdlc/proof.json" ] || valid=false
+    rm -rf "$ws" "$fakebin"
+
+    if [ "$valid" = "true" ]; then
+        pass "universal proof validates explicit PowerShell host wrappers"
+    else
+        printf '%s\n' "$output" >&2
+        fail "universal proof bypassed validation for an explicit PowerShell host wrapper"
+    fi
+}
+
+test_universal_proof_checks_every_pester_entry_from_zero_depth() {
+    local ws fakebin module_root test_psmodule_path output status valid=true
+    ws=$(mktemp -d)
+    fakebin=$(mktemp -d)
+    mkdir -p "$ws/.codex/hooks"
+    cp "$UNIVERSAL_PRETOOL_SCRIPT" "$ws/.codex/hooks/git-guard.cjs"
+    printf '%s\n' 'proof-target' > "$ws/app.txt"
+    (cd "$ws" && git init -q && git add app.txt)
+    if command -v pwsh >/dev/null 2>&1 || command -v powershell.exe >/dev/null 2>&1; then
+        module_root="$ws/modules"
+        write_fake_pester_module "$module_root"
+        if [ "$IS_WINDOWS" = "true" ]; then
+            test_psmodule_path="$(cygpath -w "$module_root");$PSModulePath"
+        else
+            test_psmodule_path="$module_root${PSModulePath:+:$PSModulePath}"
+        fi
+    else
+        cat > "$fakebin/pwsh" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+        chmod +x "$fakebin/pwsh"
+        test_psmodule_path="${PSModulePath:-}"
+    fi
+
+    set +e
+    output=$(cd "$ws" && PSModulePath="$test_psmodule_path" PATH="$fakebin:$PATH" \
+        node .codex/hooks/git-guard.cjs prove --reviewed \
+        --check true --check true --check true --check true --check true \
+        --check true --check true --check true --check true \
+        --check "Invoke-Pester -Path tests -EnableExit" 2>&1)
+    status=$?
+    set -e
+
+    [ "$status" -eq 0 ] || valid=false
+    echo "$output" | grep -Fq 'Wrote SDLC proof:' || valid=false
+    [ -e "$ws/.git/codex-sdlc/proof.json" ] || valid=false
+    rm -rf "$ws" "$fakebin"
+
+    if [ "$valid" = "true" ]; then
+        pass "universal proof validates every Pester check from recursion depth zero"
+    else
+        printf '%s\n' "$output" >&2
+        fail "universal proof leaked the Array.find callback index into Pester recursion depth"
     fi
 }
 
@@ -333,9 +842,11 @@ echo none-cli regression sentinel
 EOF
         cat > "$fakebin/pwsh" <<'EOF'
 #!/bin/sh
+[ "$CODEX_SDLC_VALIDATE_ONLY" = "1" ] && exit 0
 [ "$1" = "-NoProfile" ] || exit 97
-[ "$2" = "-Command" ] || exit 98
-exec sh -c "$3"
+[ "$2" = "-EncodedCommand" ] || exit 98
+decoded=$(node -e 'process.stdout.write(Buffer.from(process.argv[1], "base64").toString("utf16le"))' "$3")
+exec sh -c "$decoded"
 EOF
         chmod +x "$fakebin/none-cli" "$fakebin/pwsh"
     fi
@@ -4486,7 +4997,19 @@ test_docs_document_proof_stamp_gate() {
         && grep -q 'GIT_NAMESPACE' "$REPO_DIR/PROVE-IT.md" \
         && grep -q 'GIT_OBJECT_DIRECTORY' "$REPO_DIR/PROVE-IT.md" \
         && grep -q 'git -C' "$REPO_DIR/README.md" \
-        && grep -q 'git -C' "$REPO_DIR/PROVE-IT.md"; then
+        && grep -q 'git -C' "$REPO_DIR/PROVE-IT.md" \
+        && grep -q 'Invoke-Pester' "$REPO_DIR/README.md" \
+        && grep -q -- '-EnableExit' "$REPO_DIR/README.md" \
+        && grep -q 'Invoke-Pester' "$REPO_DIR/PROVE-IT.md" \
+        && grep -q -- '-EnableExit' "$REPO_DIR/PROVE-IT.md" \
+        && grep -q 'scan.language' "$REPO_DIR/README.md" \
+        && grep -q '`"PowerShell"`' "$REPO_DIR/README.md" \
+        && grep -q '& ./tests.ps1' "$REPO_DIR/README.md" \
+        && grep -q 'mixed shell/PowerShell' "$REPO_DIR/README.md" \
+        && grep -q 'scan.language' "$REPO_DIR/PROVE-IT.md" \
+        && grep -q '`"PowerShell"`' "$REPO_DIR/PROVE-IT.md" \
+        && grep -q '& ./tests.ps1' "$REPO_DIR/PROVE-IT.md" \
+        && grep -q 'mixed shell/PowerShell' "$REPO_DIR/PROVE-IT.md"; then
         pass "docs document the proof-stamp git gate"
     else
         fail "docs should explain the proof-stamp git gate"
@@ -4506,6 +5029,12 @@ test_session_silent_when_present
 test_universal_pretool_blocks_commit
 test_universal_pretool_allows_commit_with_fresh_proof
 test_universal_proof_runs_powershell_manifest_commands_in_pwsh
+test_universal_proof_rejects_shell_prefixed_powershell_hosts
+test_universal_proof_preserves_powershell_names_as_data
+test_universal_proof_rejects_pester_without_exit_propagation
+test_universal_proof_accepts_pester_switch_after_quoted_separators
+test_universal_proof_checks_every_pester_entry_from_zero_depth
+test_universal_proof_validates_explicit_powershell_host_wrappers
 test_universal_proof_ignores_placeholder_manifest_commands
 test_universal_proof_preserves_commands_that_begin_with_none
 test_universal_pretool_blocks_stale_proof

--- a/tests/test-npm.sh
+++ b/tests/test-npm.sh
@@ -213,7 +213,7 @@ test_local_npx_installs_into_clean_repo() {
         mkdir -p "$target_repo/src"
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard --yes >/dev/null 2>&1
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard --yes >/dev/null 2>&1
         ) || installed=false
     fi
 
@@ -261,7 +261,7 @@ test_local_npx_setup_honors_model_profile_flag() {
     else
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum >/dev/null 2>&1
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum >/dev/null 2>&1
         ) || configured=false
     fi
 
@@ -313,13 +313,13 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
 
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes >/dev/null 2>&1
         ) || valid=false
 
         output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard 2>&1
         ) || valid=false
     fi
@@ -364,19 +364,19 @@ test_packed_tarball_scratch_smoke() {
 
         setup_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes 2>&1
         ) || valid=false
 
         check_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard check 2>&1
         ) || valid=false
 
         update_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard update check-only 2>&1
         ) || valid=false
     fi

--- a/tests/test-npm.sh
+++ b/tests/test-npm.sh
@@ -199,7 +199,7 @@ test_local_npx_installs_into_clean_repo() {
     local npm_cache
     npm_cache=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-cache.XXXXXX")
 
-    local json tarball_name
+    local json tarball_name install_output=""
     json=$(cd "$REPO_DIR" && npm_config_cache="$npm_cache" npm pack --json --pack-destination "$pack_dir" 2>/dev/null) || true
     tarball_name=$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] ? data[0].filename : ""')
 
@@ -211,9 +211,9 @@ test_local_npx_installs_into_clean_repo() {
     else
         printf '%s' '{"name":"install-smoke","scripts":{"test":"jest"}}' > "$target_repo/package.json"
         mkdir -p "$target_repo/src"
-        (
-            cd "$target_repo"
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard --yes >/dev/null 2>&1
+        install_output=$(
+            cd "$target_repo" &&
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard --yes 2>&1
         ) || installed=false
     fi
 
@@ -233,13 +233,15 @@ test_local_npx_installs_into_clean_repo() {
     grep -q 'powershell\.exe' "$target_repo/.codex/hooks.json" 2>/dev/null && installed=false
     grep -q 'bash-guard\.sh' "$target_repo/.codex/hooks.json" 2>/dev/null && installed=false
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
-
     if [ "$installed" = "true" ]; then
         pass "local npm exec defaults to adaptive setup with universal Node hooks when automation passes --yes"
     else
+        printf '%s\n' "--- local npm exec install package spec ---" "$(native_npm_package_spec "$tarball_path")" >&2
+        printf '%s\n' "--- local npm exec install output ---" "$install_output" >&2
         fail "local npm exec did not route the default command through adaptive setup with universal Node hooks"
     fi
+
+    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
 }
 
 test_local_npx_setup_honors_model_profile_flag() {
@@ -249,7 +251,7 @@ test_local_npx_setup_honors_model_profile_flag() {
     local npm_cache
     npm_cache=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-cache.XXXXXX")
 
-    local json tarball_name
+    local json tarball_name configured_output=""
     json=$(cd "$REPO_DIR" && npm_config_cache="$npm_cache" npm pack --json --pack-destination "$pack_dir" 2>/dev/null) || true
     tarball_name=$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] ? data[0].filename : ""')
 
@@ -259,9 +261,9 @@ test_local_npx_setup_honors_model_profile_flag() {
     if [ -z "$tarball_name" ] || [ ! -f "$tarball_path" ]; then
         configured=false
     else
-        (
-            cd "$target_repo"
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum >/dev/null 2>&1
+        configured_output=$(
+            cd "$target_repo" &&
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum 2>&1
         ) || configured=false
     fi
 
@@ -282,13 +284,15 @@ test_local_npx_setup_honors_model_profile_flag() {
         fi
     fi
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
-
     if [ "$configured" = "true" ]; then
         pass "local npm exec setup honors the model-profile flag"
     else
+        printf '%s\n' "--- local npm exec profile package spec ---" "$(native_npm_package_spec "$tarball_path")" >&2
+        printf '%s\n' "--- local npm exec profile output ---" "$configured_output" >&2
         fail "local npm exec setup did not honor the model-profile flag"
     fi
+
+    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
 }
 
 test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
@@ -298,7 +302,7 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
     local npm_cache
     npm_cache=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-cache.XXXXXX")
 
-    local json tarball_name tarball_path output
+    local json tarball_name tarball_path output="" setup_output=""
     json=$(cd "$REPO_DIR" && npm_config_cache="$npm_cache" npm pack --json --pack-destination "$pack_dir" 2>/dev/null) || true
     tarball_name=$(printf '%s' "$json" | json_get_stdin 'Array.isArray(data) && data[0] ? data[0].filename : ""')
     tarball_path="$pack_dir/$tarball_name"
@@ -311,10 +315,10 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
         printf '%s' '{"name":"initialized-clone","scripts":{"test":"jest"}}' > "$target_repo/package.json"
         mkdir -p "$target_repo/src"
 
-        (
-            cd "$target_repo"
+        setup_output=$(
+            cd "$target_repo" &&
             MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
-                codex-sdlc-wizard setup --yes >/dev/null 2>&1
+                codex-sdlc-wizard setup --yes 2>&1
         ) || valid=false
 
         output=$(
@@ -332,13 +336,16 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
     [ -f "$target_repo/.codex-home-second/skills/update-wizard/SKILL.md" ] || valid=false
     [ -f "$target_repo/.codex-home-second/skills/feedback/SKILL.md" ] || valid=false
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
-
     if [ "$valid" = "true" ]; then
         pass "default CLI updates initialized clones without an explicit subcommand"
     else
+        printf '%s\n' "--- initialized clone package spec ---" "$(native_npm_package_spec "$tarball_path")" >&2
+        printf '%s\n' "--- initialized clone setup output ---" "$setup_output" >&2
+        printf '%s\n' "--- initialized clone update output ---" "$output" >&2
         fail "default CLI did not auto-run update for an initialized clone"
     fi
+
+    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
 }
 
 test_packed_tarball_scratch_smoke() {
@@ -391,13 +398,17 @@ test_packed_tarball_scratch_smoke() {
     echo "$check_output" | grep -q '"status": "match"' || valid=false
     echo "$update_output" | grep -Eq 'No managed files need updates|"status": "match"|match' || valid=false
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
-
     if [ "$valid" = "true" ]; then
         pass "packed tarball scratch smoke proves setup, check, and update on a clean repo"
     else
+        printf '%s\n' "--- packed scratch package spec ---" "$(native_npm_package_spec "$tarball_path")" >&2
+        printf '%s\n' "--- packed scratch setup output ---" "$setup_output" >&2
+        printf '%s\n' "--- packed scratch check output ---" "$check_output" >&2
+        printf '%s\n' "--- packed scratch update output ---" "$update_output" >&2
         fail "packed tarball scratch smoke did not prove the release surface cleanly"
     fi
+
+    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
 }
 
 test_default_interactive_hands_off_to_codex() {

--- a/tests/test-npm.sh
+++ b/tests/test-npm.sh
@@ -19,11 +19,14 @@ case "$(uname -s)" in
     *) IS_WINDOWS=false ;;
 esac
 
-native_node_path() {
+native_npm_package_spec() {
     local candidate="$1"
+    local native_path
 
     if [ "$IS_WINDOWS" = "true" ]; then
-        if ! cygpath -am "$candidate"; then
+        if native_path=$(cygpath -am "$candidate"); then
+            printf 'file:%s\n' "$native_path"
+        else
             printf 'warning: could not convert npm package path for Windows: %s\n' "$candidate" >&2
             printf '%s\n' "$candidate"
         fi
@@ -210,7 +213,7 @@ test_local_npx_installs_into_clean_repo() {
         mkdir -p "$target_repo/src"
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- codex-sdlc-wizard --yes >/dev/null 2>&1
+            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard --yes >/dev/null 2>&1
         ) || installed=false
     fi
 
@@ -258,7 +261,7 @@ test_local_npx_setup_honors_model_profile_flag() {
     else
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum >/dev/null 2>&1
+            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum >/dev/null 2>&1
         ) || configured=false
     fi
 
@@ -310,13 +313,13 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
 
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
+            CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes >/dev/null 2>&1
         ) || valid=false
 
         output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
+            CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard 2>&1
         ) || valid=false
     fi
@@ -361,19 +364,19 @@ test_packed_tarball_scratch_smoke() {
 
         setup_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
+            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes 2>&1
         ) || valid=false
 
         check_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
+            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard check 2>&1
         ) || valid=false
 
         update_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
+            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard update check-only 2>&1
         ) || valid=false
     fi

--- a/tests/test-npm.sh
+++ b/tests/test-npm.sh
@@ -36,6 +36,37 @@ native_npm_package_spec() {
     printf '%s\n' "$candidate"
 }
 
+make_supported_codex_stub() {
+    local fakebin="$1"
+    local fakebin_win
+
+    cat > "$fakebin/codex" <<'EOF'
+#!/bin/sh
+if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then
+  echo "codex-cli 0.144.0"
+  exit 0
+fi
+exit 97
+EOF
+    chmod +x "$fakebin/codex"
+
+    cat > "$fakebin/codex.cmd" <<'EOF'
+@echo off
+if not "%2"=="" exit /b 97
+if "%~1"=="--version" (
+  echo codex-cli 0.144.0
+  exit /b 0
+)
+exit /b 97
+EOF
+
+    if fakebin_win=$(cd "$fakebin" && pwd -W 2>/dev/null); then
+        printf '%s\\codex.cmd\n' "$fakebin_win"
+    else
+        printf '%s/codex\n' "$fakebin"
+    fi
+}
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -193,9 +224,11 @@ test_npm_pack_includes_runtime_files() {
 }
 
 test_local_npx_installs_into_clean_repo() {
-    local pack_dir target_repo
+    local pack_dir target_repo fakebin codex_bin
     pack_dir=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-pack.XXXXXX")
     target_repo=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
+    fakebin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-bin.XXXXXX")
+    codex_bin=$(make_supported_codex_stub "$fakebin")
     local npm_cache
     npm_cache=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-cache.XXXXXX")
 
@@ -213,7 +246,7 @@ test_local_npx_installs_into_clean_repo() {
         mkdir -p "$target_repo/src"
         install_output=$(
             cd "$target_repo" &&
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard --yes 2>&1
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_CODEX_BIN="$codex_bin" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard --yes 2>&1
         ) || installed=false
     fi
 
@@ -241,13 +274,15 @@ test_local_npx_installs_into_clean_repo() {
         fail "local npm exec did not route the default command through adaptive setup with universal Node hooks"
     fi
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
+    rm -rf "$pack_dir" "$target_repo" "$fakebin" "$npm_cache"
 }
 
 test_local_npx_setup_honors_model_profile_flag() {
-    local pack_dir target_repo
+    local pack_dir target_repo fakebin codex_bin
     pack_dir=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-pack.XXXXXX")
     target_repo=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
+    fakebin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-bin.XXXXXX")
+    codex_bin=$(make_supported_codex_stub "$fakebin")
     local npm_cache
     npm_cache=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-cache.XXXXXX")
 
@@ -263,7 +298,7 @@ test_local_npx_setup_honors_model_profile_flag() {
     else
         configured_output=$(
             cd "$target_repo" &&
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum 2>&1
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_CODEX_BIN="$codex_bin" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum 2>&1
         ) || configured=false
     fi
 
@@ -292,13 +327,15 @@ test_local_npx_setup_honors_model_profile_flag() {
         fail "local npm exec setup did not honor the model-profile flag"
     fi
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
+    rm -rf "$pack_dir" "$target_repo" "$fakebin" "$npm_cache"
 }
 
 test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
-    local pack_dir target_repo
+    local pack_dir target_repo fakebin codex_bin
     pack_dir=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-pack.XXXXXX")
     target_repo=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
+    fakebin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-bin.XXXXXX")
+    codex_bin=$(make_supported_codex_stub "$fakebin")
     local npm_cache
     npm_cache=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-cache.XXXXXX")
 
@@ -317,13 +354,13 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
 
         setup_output=$(
             cd "$target_repo" &&
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_CODEX_BIN="$codex_bin" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes 2>&1
         ) || valid=false
 
         output=$(
             cd "$target_repo" && \
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_CODEX_BIN="$codex_bin" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard 2>&1
         ) || valid=false
     fi
@@ -345,13 +382,15 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
         fail "default CLI did not auto-run update for an initialized clone"
     fi
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
+    rm -rf "$pack_dir" "$target_repo" "$fakebin" "$npm_cache"
 }
 
 test_packed_tarball_scratch_smoke() {
-    local pack_dir target_repo
+    local pack_dir target_repo fakebin codex_bin
     pack_dir=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-pack.XXXXXX")
     target_repo=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
+    fakebin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-bin.XXXXXX")
+    codex_bin=$(make_supported_codex_stub "$fakebin")
     local npm_cache
     npm_cache=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-cache.XXXXXX")
 
@@ -371,19 +410,19 @@ test_packed_tarball_scratch_smoke() {
 
         setup_output=$(
             cd "$target_repo" && \
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_CODEX_BIN="$codex_bin" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes 2>&1
         ) || valid=false
 
         check_output=$(
             cd "$target_repo" && \
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_CODEX_BIN="$codex_bin" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard check 2>&1
         ) || valid=false
 
         update_output=$(
             cd "$target_repo" && \
-            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
+            MSYS2_ARG_CONV_EXCL='file:' CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_CODEX_BIN="$codex_bin" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_npm_package_spec "$tarball_path")" -- \
                 codex-sdlc-wizard update check-only 2>&1
         ) || valid=false
     fi
@@ -408,7 +447,7 @@ test_packed_tarball_scratch_smoke() {
         fail "packed tarball scratch smoke did not prove the release surface cleanly"
     fi
 
-    rm -rf "$pack_dir" "$target_repo" "$npm_cache"
+    rm -rf "$pack_dir" "$target_repo" "$fakebin" "$npm_cache"
 }
 
 test_default_interactive_hands_off_to_codex() {

--- a/tests/test-npm.sh
+++ b/tests/test-npm.sh
@@ -19,6 +19,20 @@ case "$(uname -s)" in
     *) IS_WINDOWS=false ;;
 esac
 
+native_node_path() {
+    local candidate="$1"
+
+    if [ "$IS_WINDOWS" = "true" ]; then
+        if ! cygpath -am "$candidate"; then
+            printf 'warning: could not convert npm package path for Windows: %s\n' "$candidate" >&2
+            printf '%s\n' "$candidate"
+        fi
+        return
+    fi
+
+    printf '%s\n' "$candidate"
+}
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -196,7 +210,7 @@ test_local_npx_installs_into_clean_repo() {
         mkdir -p "$target_repo/src"
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$tarball_path" -- codex-sdlc-wizard --yes >/dev/null 2>&1
+            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- codex-sdlc-wizard --yes >/dev/null 2>&1
         ) || installed=false
     fi
 
@@ -244,7 +258,7 @@ test_local_npx_setup_honors_model_profile_flag() {
     else
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$tarball_path" -- codex-sdlc-wizard setup --yes --model-profile maximum >/dev/null 2>&1
+            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- codex-sdlc-wizard setup --yes --model-profile maximum >/dev/null 2>&1
         ) || configured=false
     fi
 
@@ -296,13 +310,13 @@ test_default_cli_updates_initialized_repo_without_explicit_subcommand() {
 
         (
             cd "$target_repo"
-            CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$tarball_path" -- \
+            CODEX_HOME="$target_repo/.codex-home-first" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes >/dev/null 2>&1
         ) || valid=false
 
         output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$tarball_path" -- \
+            CODEX_HOME="$target_repo/.codex-home-second" CODEX_SDLC_DISABLE_CODEX_HANDOFF=1 CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
                 codex-sdlc-wizard 2>&1
         ) || valid=false
     fi
@@ -347,19 +361,19 @@ test_packed_tarball_scratch_smoke() {
 
         setup_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$tarball_path" -- \
+            CODEX_HOME="$target_repo/.codex-home" CODEX_SDLC_DISABLE_REASONING=1 npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
                 codex-sdlc-wizard setup --yes 2>&1
         ) || valid=false
 
         check_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$tarball_path" -- \
+            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
                 codex-sdlc-wizard check 2>&1
         ) || valid=false
 
         update_output=$(
             cd "$target_repo" && \
-            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$tarball_path" -- \
+            CODEX_HOME="$target_repo/.codex-home" npm_config_cache="$npm_cache" npm exec --yes --package "$(native_node_path "$tarball_path")" -- \
                 codex-sdlc-wizard update check-only 2>&1
         ) || valid=false
     fi
@@ -436,6 +450,7 @@ EOF
 
     output=$(
         cd "$ws" && \
+        CI=false \
         CODEX_HOME="$codex_home" \
         CODEX_SDLC_CODEX_BIN="$codex_bin" \
         CODEX_SDLC_DISABLE_REASONING=1 \
@@ -523,6 +538,7 @@ EOF
     set +e
     output=$(
         cd "$ws" && \
+        CI=false \
         CODEX_HOME="$codex_home" \
         CODEX_SDLC_CODEX_BIN="$codex_bin" \
         CODEX_SDLC_DISABLE_REASONING=1 \
@@ -581,6 +597,7 @@ EOF
     set +e
     (
         cd "$ws" || exit 1
+        CI=false \
         CODEX_HOME="$codex_home" \
         CODEX_SDLC_CODEX_BIN="$fakebin/codex" \
         CODEX_SDLC_DISABLE_REASONING=1 \
@@ -604,7 +621,7 @@ EOF
 }
 
 test_unsupported_codex_version_blocks_handoff_before_mutation() {
-    local ws fakebin codex_home output status valid=true
+    local ws fakebin fakebin_win codex_bin codex_path_entry codex_home output status valid=true
     ws=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
     fakebin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-bin.XXXXXX")
     codex_home=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-home.XXXXXX")
@@ -623,12 +640,30 @@ exit 99
 EOF
     chmod +x "$fakebin/codex"
 
+    cat > "$fakebin/codex.cmd" <<'EOF'
+@echo off
+if "%~1"=="--version" (
+  echo launcher 9.9.9 warning
+  echo codex-cli 0.143.9
+  exit /b 0
+)
+exit /b 99
+EOF
+
+    codex_path_entry="$fakebin"
+    if fakebin_win=$(cd "$fakebin" && pwd -W 2>/dev/null); then
+        codex_bin="$fakebin_win\\codex.cmd"
+    else
+        codex_bin="$fakebin/codex"
+    fi
+
     set +e
     output=$(
         cd "$ws" && \
+        CI=false \
         CODEX_HOME="$codex_home" \
-        CODEX_SDLC_CODEX_BIN="$fakebin/codex" \
-        PATH="$fakebin:$PATH" \
+        CODEX_SDLC_CODEX_BIN="$codex_bin" \
+        PATH="$codex_path_entry:$PATH" \
         node "$REPO_DIR/bin/codex-sdlc-wizard.js" 2>&1
     )
     status=$?
@@ -636,6 +671,7 @@ EOF
 
     [ "$status" -ne 0 ] || valid=false
     echo "$output" | grep -Fq 'Codex CLI 0.144.0 or newer' || valid=false
+    echo "$output" | grep -Fq 'found 0.143.9' || valid=false
     echo "$output" | grep -Fq 'npm install -g @openai/codex@latest' || valid=false
     [ ! -e "$ws/.codex/config.toml" ] || valid=false
     [ ! -e "$ws/.codex-sdlc/model-profile.json" ] || valid=false
@@ -650,7 +686,7 @@ EOF
 }
 
 test_configured_codex_binary_drives_installer_version_gate() {
-    local ws oldbin currentbin codex_home output status valid=true
+    local ws oldbin currentbin oldbin_win currentbin_win codex_bin codex_path_entry codex_home output status valid=true
     ws=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-target.XXXXXX")
     oldbin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-old-bin.XXXXXX")
     currentbin=$(mktemp -d "$MKTEMP_DIR/sdlc-npx-current-bin.XXXXXX")
@@ -675,13 +711,36 @@ exit 0
 EOF
     chmod +x "$oldbin/codex" "$currentbin/codex"
 
+    cat > "$oldbin/codex.cmd" <<'EOF'
+@echo off
+if "%~1"=="--version" (
+  echo codex-cli 0.143.9
+  exit /b 0
+)
+exit /b 99
+EOF
+    cat > "$currentbin/codex.cmd" <<'EOF'
+@echo off
+if "%~1"=="--version" echo codex-cli 0.144.0
+exit /b 0
+EOF
+
+    codex_path_entry="$oldbin"
+    if oldbin_win=$(cd "$oldbin" && pwd -W 2>/dev/null) \
+        && currentbin_win=$(cd "$currentbin" && pwd -W 2>/dev/null); then
+        codex_bin="$currentbin_win\\codex.cmd"
+    else
+        codex_bin="$currentbin/codex"
+    fi
+
     set +e
     output=$(
         cd "$ws" && \
+        CI=false \
         CODEX_HOME="$codex_home" \
-        CODEX_SDLC_CODEX_BIN="$currentbin/codex" \
+        CODEX_SDLC_CODEX_BIN="$codex_bin" \
         CODEX_SDLC_HANDOFF_MODE=plain \
-        PATH="$oldbin:$PATH" \
+        PATH="$codex_path_entry:$PATH" \
         node "$REPO_DIR/bin/codex-sdlc-wizard.js" </dev/null 2>&1
     )
     status=$?
@@ -690,6 +749,8 @@ EOF
     [ "$status" -eq 0 ] || valid=false
     [ -f "$ws/.codex/config.toml" ] || valid=false
     grep -q '^model = "gpt-5.6-sol"' "$ws/.codex/config.toml" 2>/dev/null || valid=false
+    echo "$output" | grep -Fq 'Handing off into Codex for live setup using plain codex' || valid=false
+    echo "$output" | grep -Fq 'Scanning project...' && valid=false
     echo "$output" | grep -Fq 'found 0.143.9' && valid=false
 
     rm -rf "$ws" "$oldbin" "$currentbin" "$codex_home"
@@ -754,6 +815,7 @@ EOF
 
     output=$(
         cd "$ws" && \
+        CI=false \
         CODEX_HOME="$codex_home" \
         CODEX_SDLC_CODEX_BIN="$codex_bin" \
         CODEX_SDLC_DISABLE_REASONING=1 \
@@ -834,6 +896,7 @@ EOF
 
     output=$(
         cd "$ws" && \
+        CI=false \
         CODEX_HOME="$codex_home" \
         CODEX_SDLC_CODEX_BIN="$codex_bin" \
         CODEX_SDLC_DISABLE_REASONING=1 \
@@ -932,6 +995,7 @@ EOF
     set +e
     output=$(
         cd "$ws" && \
+        CI=false \
         CODEX_HOME="$codex_home" \
         CODEX_SDLC_CODEX_BIN="$codex_bin" \
         CODEX_SDLC_DISABLE_REASONING=1 \

--- a/tests/test-roadmap.sh
+++ b/tests/test-roadmap.sh
@@ -7,7 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$SCRIPT_DIR/.."
 ROADMAP="$REPO_DIR/ROADMAP.md"
 PACKAGE_JSON="$REPO_DIR/package.json"
-REPOSITORY_URL="https://github.com/BaseInfinity/codex-sdlc-wizard"
+REPOSITORY_URL_REGEX='https://github[.]com/BaseInfinity/codex-sdlc-wizard'
+OPEN_ISSUES="58 64 65 66 71 72 73 77 79 82 84 86 88 92 93 95 96 97 98 99 100 101"
 PASSED=0
 FAILED=0
 
@@ -27,7 +28,29 @@ fail() {
 
 issue_line() {
     local issue_number="$1"
-    grep -nF "$REPOSITORY_URL/issues/$issue_number" "$ROADMAP" | cut -d: -f1 | head -n1 || true
+    grep -nE "$REPOSITORY_URL_REGEX/issues/$issue_number([^0-9]|$)" "$ROADMAP" | cut -d: -f1 | head -n1 || true
+}
+
+roadmap_has_issue() {
+    local issue_number="$1"
+    grep -Eq "$REPOSITORY_URL_REGEX/issues/$issue_number([^0-9]|$)" "$ROADMAP"
+}
+
+priority_section() {
+    awk '
+        /^## Priority queue$/ { in_queue = 1; next }
+        /^## / { if (in_queue) exit }
+        in_queue { print }
+    ' "$ROADMAP"
+}
+
+priority_lines() {
+    priority_section | grep -E '^[0-9]+[.] ' || true
+}
+
+priority_has_issue() {
+    local issue_number="$1"
+    priority_lines | grep -Eq "$REPOSITORY_URL_REGEX/issues/$issue_number([^0-9]|$)"
 }
 
 echo "=== Roadmap Tests ==="
@@ -71,30 +94,114 @@ test_roadmap_states_current_release() {
     fi
 }
 
-test_roadmap_links_every_open_issue() {
+test_roadmap_links_post_merge_open_issue_snapshot() {
     local issue_number
     local missing=0
-    local post_merge_open_issues="58 64 65 66 67 71 72 73 77 79 81 82 84 86 88 92"
-
-    for issue_number in $post_merge_open_issues; do
-        if ! grep -Fq "$REPOSITORY_URL/issues/$issue_number" "$ROADMAP"; then
-            echo "Missing issue link: #$issue_number"
+    # Offline completeness snapshot. Update this list in the same change that
+    # reconciles GitHub issue state and ROADMAP priority.
+    for issue_number in $OPEN_ISSUES; do
+        if ! priority_has_issue "$issue_number"; then
+            echo "Missing open issue link: #$issue_number"
             missing=$((missing + 1))
         fi
     done
 
     if [ "$missing" -eq 0 ]; then
-        pass "Roadmap links every GitHub issue that remains open after this change"
+        pass "Roadmap links the post-merge open-issue snapshot"
     else
-        fail "Roadmap is missing $missing open issue link(s)"
+        fail "Roadmap is missing $missing current open issue link(s)"
     fi
 }
 
-test_roadmap_top_order_matches_release_priority() {
+test_roadmap_rejects_unknown_issue_links() {
+    local issue_number
+    local unexpected=0
+
+    while IFS= read -r issue_number; do
+        [ -n "$issue_number" ] || continue
+        case " $OPEN_ISSUES " in
+            *" $issue_number "*) ;;
+            *)
+                echo "Unexpected issue link in priority queue: #$issue_number"
+                unexpected=$((unexpected + 1))
+                ;;
+        esac
+    done < <(priority_lines | grep -Eo "$REPOSITORY_URL_REGEX/issues/[0-9]+" | sed 's#.*/##' || true)
+
+    if [ "$unexpected" -eq 0 ]; then
+        pass "Roadmap priority queue contains only current open issues"
+    else
+        fail "Roadmap contains $unexpected stale or unknown issue link(s)"
+    fi
+}
+
+test_roadmap_priority_section_contains_only_numbered_items() {
+    local invalid=0
+    local line
+
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        if ! grep -Eq '^[0-9]+[.] ' <<<"$line"; then
+            echo "Malformed priority item: $line"
+            invalid=$((invalid + 1))
+        fi
+    done < <(priority_section)
+
+    if [ "$invalid" -eq 0 ]; then
+        pass "Roadmap priority section contains only numbered items"
+    else
+        fail "Roadmap has $invalid malformed priority item(s)"
+    fi
+}
+
+test_roadmap_excludes_resolved_issues() {
+    local issue_number
+    local stale=0
+    local closed_issues="67 81 91"
+
+    for issue_number in $closed_issues; do
+        if roadmap_has_issue "$issue_number"; then
+            echo "Roadmap retains resolved issue: #$issue_number"
+            stale=$((stale + 1))
+        fi
+    done
+
+    if [ "$stale" -eq 0 ]; then
+        pass "Roadmap excludes resolved issues"
+    else
+        fail "Roadmap retains $stale resolved issue(s)"
+    fi
+}
+
+test_roadmap_priority_numbers_are_contiguous() {
+    local expected=1
+    local actual
+    local inspected=0
+    local line
+
+    while IFS= read -r line; do
+        inspected=$((inspected + 1))
+        actual="${line%%.*}"
+        if [ "$actual" -ne "$expected" ]; then
+            fail "Roadmap priority numbering is not contiguous at item $actual"
+            return
+        fi
+        expected=$((expected + 1))
+    done < <(priority_lines)
+
+    if [ "$inspected" -eq 0 ]; then
+        fail "Roadmap has no numbered priorities"
+        return
+    fi
+
+    pass "Roadmap priority numbering is contiguous"
+}
+
+test_roadmap_head_order_matches_priority() {
     local previous=0
     local current
     local issue_number
-    local ordered_issues="79 92 73 65 67 84 88 66"
+    local ordered_issues="98 86 73 92 93 84 88 79 64 95 100 101 66"
 
     for issue_number in $ordered_issues; do
         current=$(issue_line "$issue_number")
@@ -105,21 +212,28 @@ test_roadmap_top_order_matches_release_priority() {
         previous="$current"
     done
 
-    pass "Roadmap orders the 0.7.36 release queue by priority"
+    pass "Roadmap orders the release and distribution queue by priority"
 }
 
-test_roadmap_keeps_upstream_issues_together() {
-    local line_65
-    local line_81
+test_roadmap_does_not_duplicate_issue_owners() {
+    local issue_number
+    local line
+    local seen=""
 
-    line_65=$(issue_line 65)
-    line_81=$(issue_line 81)
+    while IFS= read -r line; do
+        while IFS= read -r issue_number; do
+            [ -n "$issue_number" ] || continue
+            case " $seen " in
+                *" $issue_number "*)
+                    fail "Roadmap duplicates issue #$issue_number across priorities"
+                    return
+                    ;;
+            esac
+            seen="$seen $issue_number"
+        done < <(grep -Eo "$REPOSITORY_URL_REGEX/issues/[0-9]+" <<<"$line" | sed 's#.*/##' || true)
+    done < <(priority_lines)
 
-    if [ -n "$line_65" ] && [ "$line_65" = "$line_81" ]; then
-        pass "Roadmap consolidates the cumulative upstream audit links"
-    else
-        fail "Roadmap does not keep issues #65 and #81 in one timeboxed priority item"
-    fi
+    pass "Roadmap assigns each issue to at most one priority"
 }
 
 test_roadmap_requires_issue_owner_for_every_priority() {
@@ -127,11 +241,11 @@ test_roadmap_requires_issue_owner_for_every_priority() {
     local line
 
     while IFS= read -r line; do
-        if ! grep -Eq "$REPOSITORY_URL/issues/[0-9]+" <<<"$line"; then
+        if ! grep -Eq "$REPOSITORY_URL_REGEX/issues/[0-9]+([^0-9]|$)" <<<"$line"; then
             echo "Priority item has no GitHub issue: $line"
             missing_owner=$((missing_owner + 1))
         fi
-    done < <(grep -E '^[0-9]+\. ' "$ROADMAP")
+    done < <(priority_lines)
 
     if [ "$missing_owner" -eq 0 ]; then
         pass "Every roadmap priority has a GitHub issue owner"
@@ -158,9 +272,13 @@ test_roadmap_removes_stale_prose_sections() {
 test_roadmap_exists
 test_roadmap_declares_order_as_priority
 test_roadmap_states_current_release
-test_roadmap_links_every_open_issue
-test_roadmap_top_order_matches_release_priority
-test_roadmap_keeps_upstream_issues_together
+test_roadmap_links_post_merge_open_issue_snapshot
+test_roadmap_rejects_unknown_issue_links
+test_roadmap_excludes_resolved_issues
+test_roadmap_priority_section_contains_only_numbered_items
+test_roadmap_priority_numbers_are_contiguous
+test_roadmap_head_order_matches_priority
+test_roadmap_does_not_duplicate_issue_owners
 test_roadmap_requires_issue_owner_for_every_priority
 test_roadmap_removes_stale_prose_sections
 

--- a/tests/test-roadmap.sh
+++ b/tests/test-roadmap.sh
@@ -74,7 +74,7 @@ test_roadmap_states_current_release() {
 test_roadmap_links_every_open_issue() {
     local issue_number
     local missing=0
-    local post_merge_open_issues="58 64 65 66 67 71 72 73 77 79 81 82 84 85 86 88"
+    local post_merge_open_issues="58 64 65 66 67 71 72 73 77 79 81 82 84 86 88 92"
 
     for issue_number in $post_merge_open_issues; do
         if ! grep -Fq "$REPOSITORY_URL/issues/$issue_number" "$ROADMAP"; then
@@ -94,7 +94,7 @@ test_roadmap_top_order_matches_release_priority() {
     local previous=0
     local current
     local issue_number
-    local ordered_issues="79 85 73 65 67 84 88 66"
+    local ordered_issues="79 92 73 65 67 84 88 66"
 
     for issue_number in $ordered_issues; do
         current=$(issue_line "$issue_number")


### PR DESCRIPTION
## Summary
- require direct Pester proof commands to propagate failures with `-EnableExit` or `-CI`
- validate PowerShell proof commands with the native AST and preserve supported data/availability-query cases
- restore the Windows Git Bash npm/handoff baseline by using self-contained supported-Codex fixtures
- surface failure-only npm diagnostics and preserve local Windows tarball package specs
- document cross-platform migration, including mixed proof suites
- reconcile `ROADMAP.md` with the complete open GitHub issue set and make its numbered order authoritative

## Verification
- Windows GitHub Actions npm suite: 25/25
- maintainer proof suite: 11/11
- focused missing-global-Codex regression: 25/25
- exact-diff self-review: clean
- Sol High staged-patch review: no actionable findings
- Fable High final staged-patch review: no actionable findings

Closes #91
Closes #98

## Follow-ups
- #86 and #73 make Sol High and proof-aware native review consistent across the maintainer harness, generated repo-local `$sdlc`, and packaged plugin update path.
- #79 validates the published 0.7.36 release on real Windows after automated release gates pass.
- #66 submits only the hardened, Windows-verified release to the plugin directory; Codex CLI remains canonical.