### PR TITLE
docs: align roadmap with 1.0 milestones

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,39 +3,50 @@
 ## How to use this roadmap
 
 - GitHub issues are the source of truth for scope, acceptance criteria, milestones, and status.
-- The numbered order below is the project priority. The first open item is the next item to work unless `GOALS.md` names a narrower active objective.
-- `GOALS.md`, when present, is the active-scope contract. `ROADMAP.md` is the ordered backlog, not a second implementation plan.
-- When priorities change, reorder links here and update the corresponding GitHub milestones or issue bodies rather than copying their details into this file.
-- Create or deduplicate a GitHub issue before adding an actionable priority here.
-- Completed implementation history belongs in pull requests and GitHub releases, not in an ever-growing roadmap narrative.
+- The numbered order below is the project priority. The first open item is next unless the maintainer explicitly reorders the queue.
+- A GitHub milestone is a planned release; its issues are the work required for that release.
+- `ROADMAP.md` is this repository's single ordered project backlog. An optional generated `GOALS.md` may scope execution inside a consumer repo, but it never overrides this project's priority queue.
+- Reorder links here when priority changes, but keep implementation detail and completion evidence in the linked issue or pull request.
+- Every actionable item must have one issue owner. Pull requests reference or close that issue, and failing CI never merges.
 
 ## Current State
 
-- Current GitHub release: [`v0.7.35`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.35)
-- Current npm release: [`codex-sdlc-wizard@0.7.35`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.35)
-- Next release milestone: [`0.7.36 — Windows-stable plugin candidate`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/1)
+- Current GitHub release: [`v0.7.35`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.35).
+- Current npm release: [`codex-sdlc-wizard@0.7.35`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.35).
+- Next release milestone: [`1.0.0 — Bounded autonomous delivery`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/2).
+- The ten-delivery cadence pilot is installed on `main`; its measurement issue remains open until the recorded evidence supports a permanent policy.
+- Real Windows Codex Desktop and CLI acceptance is the last hardware-dependent gate. Mac/Linux implementation and proof continue before that handoff.
 
 ## Priority queue
 
-1. **Restore the Windows automation baseline** — [#98: Return the Git Bash npm/handoff suite to 25/25 passing](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/98).
-2. **Enforce the chosen Sol High policy everywhere** — [#86: Remove autonomous `xhigh` escalation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/86).
-3. **Make native review proof-aware across every shipped layer** — [#73: Avoid redundant reviewer suite reruns](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/73).
-4. **Resolve nondeterministic Windows proof cleanup** — [#92: Investigate the access-denied proof-stamp race](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/92).
-5. **Keep Windows review evidence honest** — [#93: Detect WindowsApps PowerShell before trusting Codex review validation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/93).
-6. **Codify known-good upgrade stability** — [#84: Adopt a preserve-known-good stability contract](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/84).
-7. **Publish and verify `0.7.36` after the automated release gates pass** — [#88: Publish and verify codex-sdlc-wizard 0.7.36](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88).
-8. **Validate the published release on real Windows** — [#79: Run the released plugin in Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79).
-9. **Land bounded dual-review enforcement** — [#64: Use `claude --print` as the cross-model reviewer](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/64) (`0.7.37`).
-10. **Audit instruction ownership and freshness** — [#95: Audit `AGENTS.md` against current Codex guidance](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/95) (`0.7.37`).
-11. **Make the GitHub lifecycle explicit and enforceable** — [#100: Teach issue-to-PR-to-milestone delivery](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/100) (`0.7.37`).
-12. **Rename the public harness without breaking npm compatibility** — [#101: Rename wizard to harness using the proven migration checklist](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/101) (`0.7.37`).
-13. **Submit only the hardened, Windows-verified public release** — [#66: Submit Codex SDLC Wizard to the universal Plugins Directory](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66).
-14. **Prototype the optional orchestration lane** — [#72: Benchmark Sol High orchestration with bounded Luna implementation work](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (`0.8.0`).
-15. **Add one read-only health entrypoint** — [#82: Add a Codex-native doctor flow](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82).
-16. **Timebox one cumulative upstream audit** — [#65: Audit upstream v1.74.0 through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65).
-17. **Detect public-release drift deterministically** — [#99: Add release-drift detection and issue reconciliation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/99).
-18. **Evaluate Fable before planning** — [#71: Evaluate Fable as an optional planning advisor](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/71).
-19. **Research context-pressure policy** — [#77: Research compaction thresholds and Luna subagent effects](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/77).
-20. **Research a Copilot CLI host adapter** — [#97: Evaluate GitHub Copilot CLI support](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/97).
-21. **Revisit portable enforcement after host adapters stabilize** — [#58: Evaluate portable SDLC MCP versus per-host skills](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/58).
-22. **Consider a Copilot Studio surface only after portable enforcement exists** — [#96: Evaluate a Copilot Studio front end](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/96).
+1. **Make two-reviewer reconciliation direct and bounded** — [#116: independent review, verbatim cross-feed, one reconciliation, one answer](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/116) (`1.0.0`).
+2. **Bind final approval to the exact integrated candidate** — [#111: certify the precise tree that can reach the default branch](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/111) (`1.0.0`).
+3. **Require honest RED evidence without manufacturing fake tests** — [#115: scope TDD RED to writable behavior and explicit evidence exceptions](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/115) (`1.0.0`).
+4. **Measure the bounded incremental-review pilot** — [#109: record ten eligible deliveries and decide the permanent cadence empirically](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/109) (`1.0.0`).
+5. **Eliminate nondeterministic Windows proof cleanup** — [#92: fix access-denied proof-stamp teardown](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/92) (`1.0.0`).
+6. **Keep Windows review evidence honest** — [#93: detect WindowsApps PowerShell before trusting review validation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/93) (`1.0.0`).
+7. **Run the final real-Windows acceptance gate** — [#79: validate the 1.0 candidate in Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79) (`1.0.0`, human-required).
+8. **Publish and verify the aligned release** — [#88: publish `codex-sdlc-wizard` 1.0.0 to npm and GitHub](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88) (`1.0.0`, human-required where credentials require it).
+9. **Soak the released contract in real consumer repos** — [#112: collect daily post-1.0 feedback and make only proven fixes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/112) (`1.1.0`).
+10. **Preserve known-good behavior during upgrades** — [#84: adopt a stability contract for model and harness changes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/84) (`1.1.0`).
+11. **Finish the Sol High policy migration** — [#86: enforce Sol High unless the user explicitly overrides it](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/86) (`1.1.0`).
+12. **Audit generated instruction ownership** — [#95: reconcile `AGENTS.md` with current Codex guidance](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/95) (`1.1.0`).
+13. **Teach the issue-to-PR-to-release lifecycle** — [#100: enforce bounded issue, pull-request, milestone, and merge state](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/100) (`1.1.0`).
+14. **Make sibling harnesses coexist safely** — [#106: define shared-root ownership with `claude-sdlc-harness`](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/106) (`1.1.0`).
+15. **Add one read-only health entrypoint** — [#82: implement a Codex-native doctor flow with explicit repair](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82) (`1.1.0`).
+16. **Submit the proven release to the Plugins Directory** — [#66: complete the universal directory submission](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66) (`Distribution`).
+17. **Audit CI/CD for independent value** — [#108: remove duplicate work and retain only release-enforcing evidence](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/108) (`1.2.0`).
+18. **Detect release drift deterministically** — [#99: reconcile package, tag, release, and issue state](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/99) (`1.2.0`).
+19. **Timebox the cumulative upstream audit** — [#65: evaluate upstream v1.74.0 through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65) (`1.2.0`).
+20. **Reconcile the newest upstream release** — [#113: evaluate upstream SDLC Wizard v1.96.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/113) (`1.2.0`).
+21. **Keep release documentation impact-based** — [#105: update README/release docs and add stabilized demos when they materially help](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/105) (`1.3.0`).
+22. **Consolidate redundant proof documentation** — [#104: fold `PROVE-IT.md` into `TESTING.md` by default](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/104) (`1.3.0`).
+23. **Rename wizard to harness with a controlled migration** — [#101: apply the sibling-repo migration checklist without breaking consumers](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/101) (`1.3.0`).
+24. **Clean contributor attribution only through an explicit history operation** — [#107: remove bot attribution without risking repository history](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/107) (`1.3.0`, human-required).
+25. **Research a fast incremental lane** — [#114: evaluate GPT-5.3-Codex-Spark](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/114) (research backlog).
+26. **Benchmark optional model orchestration** — [#72: compare direct Sol/Luna driving with bounded Sol-to-Luna delegation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (research backlog).
+27. **Evaluate Fable before planning** — [#71: measure Fable as an optional planning advisor](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/71) (research backlog).
+28. **Research context-pressure policy** — [#77: measure compaction thresholds and subagent effects](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/77) (research backlog).
+29. **Evaluate another CLI host** — [#97: research a GitHub Copilot CLI adapter](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/97) (research backlog).
+30. **Revisit portable enforcement after host adapters stabilize** — [#58: compare a portable SDLC MCP server with per-host skills](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/58) (research backlog).
+31. **Consider a Copilot Studio surface last** — [#96: research a front end only after portable enforcement is justified](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/96) (research backlog).

--- a/tests/test-adapter.sh
+++ b/tests/test-adapter.sh
@@ -4592,9 +4592,10 @@ test_repo_defaults_consumer_and_maintainer_work_to_sol_high() {
         all_passed=false
     fi
 
-    if grep -R -E --exclude-dir=.git --exclude-dir=node_modules --exclude=test-adapter.sh \
+    if grep -R -n -E --exclude-dir=.git --exclude-dir=node_modules --exclude=test-adapter.sh \
         --exclude=WINDOWS-E2E-FINDINGS-20260804.md \
-        'gpt-5\.(5|4|3)|GPT-5\.(5|4|3)|Codex Spark|mini-only' "$REPO_DIR" >/dev/null 2>&1; then
+        'gpt-5\.(5|4|3)|GPT-5\.(5|4|3)|Codex Spark|mini-only' "$REPO_DIR" 2>/dev/null | \
+        grep -Ev 'ROADMAP\.md:.*#114: evaluate GPT-5\.3-Codex-Spark' | grep -q .; then
         fail "repo still contains stale legacy model-family references"
         all_passed=false
     fi

--- a/tests/test-packaging.sh
+++ b/tests/test-packaging.sh
@@ -712,21 +712,22 @@ test_readme_documents_optional_goals_contract() {
     fi
 }
 
-test_roadmap_documents_optional_goals_boundary() {
-    local has_goals=true
-    local has_roadmap_boundary=true
-    local has_active_boundary=true
+test_roadmap_is_the_single_project_backlog() {
+    local has_source_of_truth=true
+    local has_single_backlog=true
+    local has_consumer_boundary=true
 
-    grep -q 'GOALS.md' "$ROADMAP" || has_goals=false
-    grep -Eqi 'ROADMAP.md.*backlog|backlog.*ROADMAP.md' "$ROADMAP" || has_roadmap_boundary=false
-    grep -Eqi 'active-scope contract|active scope contract|active contract' "$ROADMAP" || has_active_boundary=false
+    grep -Eqi 'GitHub issues.*source of truth|source of truth.*GitHub issues' "$ROADMAP" || has_source_of_truth=false
+    grep -Eqi 'single ordered project backlog|single.*backlog' "$ROADMAP" || has_single_backlog=false
+    grep -Eqi 'GOALS\.md.*consumer repo|consumer repo.*GOALS\.md' "$ROADMAP" || has_consumer_boundary=false
+    grep -Eqi 'GOALS\.md.*(never|does not).*override|never overrides.*priority queue' "$ROADMAP" || has_consumer_boundary=false
 
-    if [ "$has_goals" = "true" ] &&
-       [ "$has_roadmap_boundary" = "true" ] &&
-       [ "$has_active_boundary" = "true" ]; then
-        pass "ROADMAP documents the optional GOALS.md active-scope boundary"
+    if [ "$has_source_of_truth" = "true" ] &&
+       [ "$has_single_backlog" = "true" ] &&
+       [ "$has_consumer_boundary" = "true" ]; then
+        pass "ROADMAP is the single GitHub-backed project backlog"
     else
-        fail "ROADMAP does not document the optional GOALS.md active-scope boundary"
+        fail "ROADMAP does not remain the single GitHub-backed project backlog"
     fi
 }
 
@@ -1433,7 +1434,7 @@ test_readme_has_install_choice_table
 test_readme_explains_install_side_effects
 test_readme_mentions_packaging_test_command
 test_readme_documents_optional_goals_contract
-test_roadmap_documents_optional_goals_boundary
+test_roadmap_is_the_single_project_backlog
 test_readme_and_goals_template_document_goal_mode_with_sdlc
 test_readme_recommends_full_auto
 test_readme_stays_consumer_focused

--- a/tests/test-roadmap.sh
+++ b/tests/test-roadmap.sh
@@ -8,7 +8,7 @@ REPO_DIR="$SCRIPT_DIR/.."
 ROADMAP="$REPO_DIR/ROADMAP.md"
 PACKAGE_JSON="$REPO_DIR/package.json"
 REPOSITORY_URL_REGEX='https://github[.]com/BaseInfinity/codex-sdlc-wizard'
-OPEN_ISSUES="58 64 65 66 71 72 73 77 79 82 84 86 88 92 93 95 96 97 98 99 100 101"
+OPEN_ISSUES="58 65 66 71 72 77 79 82 84 86 88 92 93 95 96 97 99 100 101 104 105 106 107 108 109 111 112 113 114 115 116"
 PASSED=0
 FAILED=0
 
@@ -71,14 +71,15 @@ test_roadmap_declares_order_as_priority() {
 
     grep -Eqi 'GitHub issues.*source of truth|source of truth.*GitHub issues' "$ROADMAP" || has_source_of_truth=false
     grep -Eqi 'order.*priority|top.*next' "$ROADMAP" || has_priority_contract=false
-    grep -Eqi 'GOALS\.md.*active|active.*GOALS\.md' "$ROADMAP" || has_goals_boundary=false
+    grep -Eqi 'GOALS\.md.*consumer repo|consumer repo.*GOALS\.md' "$ROADMAP" || has_goals_boundary=false
+    grep -Eqi 'GOALS\.md.*(never|does not).*override|never overrides.*priority queue' "$ROADMAP" || has_goals_boundary=false
 
     if [ "$has_source_of_truth" = "true" ] &&
        [ "$has_priority_contract" = "true" ] &&
        [ "$has_goals_boundary" = "true" ]; then
         pass "Roadmap declares its GitHub-backed priority contract"
     else
-        fail "Roadmap does not clearly define source of truth, priority order, and active-goal boundaries"
+        fail "Roadmap does not clearly separate project priority from optional consumer execution scope"
     fi
 }
 
@@ -157,7 +158,7 @@ test_roadmap_priority_section_contains_only_numbered_items() {
 test_roadmap_excludes_resolved_issues() {
     local issue_number
     local stale=0
-    local closed_issues="67 81 91"
+    local closed_issues="64 67 73 81 91 98 110"
 
     for issue_number in $closed_issues; do
         if roadmap_has_issue "$issue_number"; then
@@ -201,7 +202,7 @@ test_roadmap_head_order_matches_priority() {
     local previous=0
     local current
     local issue_number
-    local ordered_issues="98 86 73 92 93 84 88 79 64 95 100 101 66"
+    local ordered_issues="116 111 115 109 92 93 79 88 112 84 86 95 100 106 82 66 108 99 65 113 105 104 101 107 114 72 71 77 97 58 96"
 
     for issue_number in $ordered_issues; do
         current=$(issue_line "$issue_number")


### PR DESCRIPTION
## Summary
- make GitHub issues and release milestones the canonical project backlog
- order all open issues by impact, with bounded-autonomy work first
- keep optional consumer `GOALS.md` separate from this repository’s `ROADMAP.md` priority
- update roadmap, packaging, and adapter invariants to enforce the contract

## Verification
- TDD RED established on stale issue/order and GOALS-boundary assertions
- targeted roadmap: 12/12
- targeted packaging: 38/38
- targeted adapter: 110/110
- full proof: 11/11
- Sol High: no actionable findings
- Fable High: certified; P3-only follow-ups do not block

Refs #109