### PR TITLE
Release 0.7.36: ship merged harness improvements

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-sdlc-wizard",
-  "version": "0.7.35",
+  "version": "0.7.36",
   "description": "Install and maintain Codex SDLC enforcement in local repositories.",
   "author": {
     "name": "BaseInfinity",

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ After either path changes skills, hooks, hook config, or helper scripts, restart
 Useful follow-ups after install:
 
 ```bash
-npx codex-sdlc-wizard@0.7.35 check
-npx codex-sdlc-wizard@0.7.35 update
+npx codex-sdlc-wizard@0.7.36 check
+npx codex-sdlc-wizard@0.7.36 update
 ```
 
 If you want pinned release examples instead of `@latest`, see [Releases](#releases).
@@ -281,10 +281,10 @@ How to choose:
 
 ```bash
 # recommended interactive bootstrap path
-npx codex-sdlc-wizard@0.7.35 --model-profile maximum
+npx codex-sdlc-wizard@0.7.36 --model-profile maximum
 
 # experimental efficiency trial when you explicitly choose it
-npx codex-sdlc-wizard@0.7.35 --model-profile mixed
+npx codex-sdlc-wizard@0.7.36 --model-profile mixed
 
 # floating latest release with the same bootstrap recommendation
 npx codex-sdlc-wizard@latest --model-profile maximum
@@ -444,6 +444,12 @@ This keeps dogfooding useful without turning every implementation session into w
 
 ## Releases
 
+`0.7.36` delivers the harness improvements already proven on `main`: bounded
+review and repair loops, proof-aware review without duplicate broad-suite
+runs, Fable cross-model review transport, one bounded Sol/Fable reconciliation,
+and the merged Windows proof/npm fixes. The exact-integration and remaining
+1.0 trust-contract work stays out of this interim release until it is complete.
+
 Versioned releases for this adapter live at:
 
 https://github.com/BaseInfinity/codex-sdlc-wizard/releases
@@ -452,7 +458,7 @@ If you are consuming this repo in a real project, prefer a tagged release over `
 
 ```bash
 # npm / npx pinned to the current release
-npx codex-sdlc-wizard@0.7.35
+npx codex-sdlc-wizard@0.7.36
 
 # npm / npx floating on the newest published release
 npx codex-sdlc-wizard@latest
@@ -462,7 +468,7 @@ npx codex-sdlc-wizard@latest
 # so $codex-sdlc-wizard is available inside Codex
 
 # git-based install
-git clone --branch v0.7.35 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
+git clone --branch v0.7.36 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
 ```
 
 ### Maintainer Release Flow

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,9 @@
 
 ## Current State
 
-- Current GitHub release: [`v0.7.35`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.35).
-- Current npm release: [`codex-sdlc-wizard@0.7.35`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.35).
+- Current release candidate: `v0.7.36`, containing the already-merged bounded-review, proof-aware review, Fable transport, bounded reconciliation, and Windows proof/npm improvements.
+- Current GitHub release after this candidate is published: [`v0.7.36`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.36).
+- Current npm release after this candidate is published: [`codex-sdlc-wizard@0.7.36`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.36).
 - Next release milestone: [`1.0.0 — Bounded autonomous delivery`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/2).
 - The ten-delivery cadence pilot is installed on `main`; its measurement issue remains open until the recorded evidence supports a permanent policy.
 - Real Windows Codex Desktop and CLI acceptance is the last hardware-dependent gate. Mac/Linux implementation and proof continue before that handoff.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-sdlc-wizard",
-  "version": "0.7.35",
+  "version": "0.7.36",
   "description": "Codex SDLC plugin, adaptive setup wizard, and maintenance CLI",
   "license": "MIT",
   "funding": {


### PR DESCRIPTION
## Summary

- bump the npm and Codex plugin versions to 0.7.36
- document the bounded-review, proof-aware review, Fable transport, bounded reconciliation, and Windows proof/npm improvements already merged on main
- point pinned install/update examples at 0.7.36

## Verification

- focused release checks: 19/19 passed
- canonical SDLC proof: 11/11 groups passed
- exact-diff self-review: clean
- Sol High + Fable High final gate: CERTIFIED (no reconciliation required)
- current GitHub Windows npm check on main: green

## Windows boundary

This interim release relies on the repository's current Windows CI and prior Windows evidence. The exact 0.7.36 candidate was not manually rerun in a real Windows Codex Desktop/CLI session. Issue #79 remains the hardware-dependent acceptance gate before 1.0.