### PR TITLE
Release 0.7.37: fix linked-worktree delivery

### DIFF
--- a/.agents/skills/sdlc/SKILL.md
+++ b/.agents/skills/sdlc/SKILL.md
@@ -37,6 +37,7 @@ Use this skill for implementation, bug-fix, refactor, testing, release, publish,
    Severity ladder: P0 stops the line; P1 blocks completion; P2 is a bounded fix now or a follow-up issue; P3 never blocks and is recorded only when worthwhile.
    When two reviewers are required, run `node .codex/hooks/dual-review.cjs --base <ref> --consent-subscription-quota`. Sol High and Fable High assess the same frozen candidate independently. Clean agreement stops immediately; a verdict split receives one verbatim cross-feed round of findings and then produces one conservative joint receipt. Do not add another reconciliation exchange. Allow at most two corrective rounds; if P0/P1 remains, decompose, abandon, or escalate rather than waiving it or continuing an unbounded loop.
    For every corrective finding, check its provenance against the base. If the blocker is candidate-born and outside the allowlist, remove that accretion instead of repairing it.
+   For a commit or push from a linked worktree, use a standalone `git -C <absolute-worktree> commit ...` or `git -C <absolute-worktree> push ...`; never rely only on the execution tool's `workdir`, because some Codex surfaces omit it from PreToolUse payloads.
    If the work is in a product repo, keep that session focused on the product repo. File a direct GitHub issue for proven reusable wizard findings and only switch to live wizard work if the product repo is actually blocked.
 11. Present a final summary with what changed, what was verified, and any residual risk.
 

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-sdlc-wizard",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "description": "Install and maintain Codex SDLC enforcement in local repositories.",
   "author": {
     "name": "BaseInfinity",

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ After either path changes skills, hooks, hook config, or helper scripts, restart
 Useful follow-ups after install:
 
 ```bash
-npx codex-sdlc-wizard@0.7.36 check
-npx codex-sdlc-wizard@0.7.36 update
+npx codex-sdlc-wizard@0.7.37 check
+npx codex-sdlc-wizard@0.7.37 update
 ```
 
 If you want pinned release examples instead of `@latest`, see [Releases](#releases).
@@ -269,6 +269,10 @@ directory. Unrelated repositories and other context changes—including `cd`,
 must be handled from a session rooted in the target repository. Inherited
 `GIT_NAMESPACE` and `GIT_OBJECT_DIRECTORY` also remain blocked because they
 retarget ref or object writes even when the worktree path itself is unchanged.
+When an agent commits or pushes from a linked worktree, it must put the absolute
+target directly in the standalone `git -C <path> ...` command instead of relying
+only on the execution tool's `workdir`; some Codex surfaces omit that field from
+the PreToolUse payload.
 
 ## Model Profiles
 
@@ -281,10 +285,10 @@ How to choose:
 
 ```bash
 # recommended interactive bootstrap path
-npx codex-sdlc-wizard@0.7.36 --model-profile maximum
+npx codex-sdlc-wizard@0.7.37 --model-profile maximum
 
 # experimental efficiency trial when you explicitly choose it
-npx codex-sdlc-wizard@0.7.36 --model-profile mixed
+npx codex-sdlc-wizard@0.7.37 --model-profile mixed
 
 # floating latest release with the same bootstrap recommendation
 npx codex-sdlc-wizard@latest --model-profile maximum
@@ -444,11 +448,11 @@ This keeps dogfooding useful without turning every implementation session into w
 
 ## Releases
 
-`0.7.36` delivers the harness improvements already proven on `main`: bounded
-review and repair loops, proof-aware review without duplicate broad-suite
-runs, Fable cross-model review transport, one bounded Sol/Fable reconciliation,
-and the merged Windows proof/npm fixes. The exact-integration and remaining
-1.0 trust-contract work stays out of this interim release until it is complete.
+`0.7.37` adds Desktop-safe linked-worktree delivery guidance: commit and push
+commands expose their absolute worktree target through `git -C`, so PreToolUse
+hooks can bind proof correctly even when a Codex surface omits the tool
+`workdir`. It includes the bounded-review, proof-aware review, Fable transport,
+bounded reconciliation, and Windows proof/npm improvements from `0.7.36`.
 
 Versioned releases for this adapter live at:
 
@@ -458,7 +462,7 @@ If you are consuming this repo in a real project, prefer a tagged release over `
 
 ```bash
 # npm / npx pinned to the current release
-npx codex-sdlc-wizard@0.7.36
+npx codex-sdlc-wizard@0.7.37
 
 # npm / npx floating on the newest published release
 npx codex-sdlc-wizard@latest
@@ -468,7 +472,7 @@ npx codex-sdlc-wizard@latest
 # so $codex-sdlc-wizard is available inside Codex
 
 # git-based install
-git clone --branch v0.7.36 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
+git clone --branch v0.7.37 --depth 1 https://github.com/BaseInfinity/codex-sdlc-wizard.git /tmp/codex-sdlc-wizard
 ```
 
 ### Maintainer Release Flow

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,9 +11,9 @@
 
 ## Current State
 
-- Current release candidate: `v0.7.36`, containing the already-merged bounded-review, proof-aware review, Fable transport, bounded reconciliation, and Windows proof/npm improvements.
-- Current GitHub release after this candidate is published: [`v0.7.36`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.36).
-- Current npm release after this candidate is published: [`codex-sdlc-wizard@0.7.36`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.36).
+- Current release candidate: `v0.7.37`, adding explicit linked-worktree Git targeting to the already-merged bounded-review, proof-aware review, Fable transport, bounded reconciliation, and Windows proof/npm improvements.
+- Current GitHub release after this candidate is published: [`v0.7.37`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.37).
+- Current npm release after this candidate is published: [`codex-sdlc-wizard@0.7.37`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.37).
 - Next release milestone: [`1.0.0 — Bounded autonomous delivery`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/2).
 - The ten-delivery cadence pilot is installed on `main`; its measurement issue remains open until the recorded evidence supports a permanent policy.
 - Real Windows Codex Desktop and CLI acceptance is the last hardware-dependent gate. Mac/Linux implementation and proof continue before that handoff.

--- a/SDLC-LOOP.md
+++ b/SDLC-LOOP.md
@@ -29,6 +29,7 @@ Codex does not have a native `/sdlc` command. This file is the honest replacemen
    Reviewer role: inspect the frozen diff and return prioritized code-review findings only; do not edit, implement, run tests, re-plan, or perform follow-up work. The builder owns every correction through the normal SDLC loop.
    When two reviewers are required, run `node .codex/hooks/dual-review.cjs --base <ref> --consent-subscription-quota`. Sol High and Fable High assess the same frozen candidate independently. Clean agreement stops immediately; a verdict split gets one verbatim cross-feed of findings before one conservative joint receipt. Consent acknowledges Claude subscription-quota use. Do not add another reconciliation exchange. Allow at most two corrective rounds. If P0/P1 remains, decompose, abandon, or escalate; never waive it or continue an unbounded review loop.
    Check every corrective finding against the base. If the blocker is candidate-born and outside the allowlist, remove that accretion instead of repairing it.
+   For a commit or push from a linked worktree, use a standalone `git -C <absolute-worktree> commit ...` or `git -C <absolute-worktree> push ...`; never rely only on the execution tool's `workdir`, because some Codex surfaces omit it from PreToolUse payloads.
 9. Escalate honestly
    If blocked, name the blocker, show the evidence, and propose the next move.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-sdlc-wizard",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "description": "Codex SDLC plugin, adaptive setup wizard, and maintenance CLI",
   "license": "MIT",
   "funding": {

--- a/skill-sources/sdlc/SKILL.template.md
+++ b/skill-sources/sdlc/SKILL.template.md
@@ -117,6 +117,8 @@ When two reviewers are required, they assess the same frozen candidate independe
 
 For every corrective finding, check its provenance against the base. If the blocker is candidate-born and outside the allowlist, remove that accretion instead of repairing it.
 
+For a commit or push from a linked worktree, use a standalone `git -C <absolute-worktree> commit ...` or `git -C <absolute-worktree> push ...`; never rely only on the execution tool's `workdir`, because some Codex surfaces omit it from PreToolUse payloads.
+
 ### 5. CI and Merge Guard
 
 Never use auto-merge in this repo.

--- a/templates/AGENTS.baseline.md
+++ b/templates/AGENTS.baseline.md
@@ -43,6 +43,7 @@ Read `TESTING.md` and `ARCHITECTURE.md` when present and relevant. If `GOALS.md`
 
 - Do not commit without passing proof.
 - Do not push without self-review.
+- For a commit or push from a linked worktree, use a standalone `git -C <absolute-worktree> commit ...` or `git -C <absolute-worktree> push ...`; never rely only on the execution tool's `workdir`, because some Codex surfaces omit it from PreToolUse payloads.
 - Preserve unrelated user changes in a dirty worktree.
 - Never use destructive git commands unless the user explicitly requests them.
 

--- a/templates/AGENTS.md.tmpl
+++ b/templates/AGENTS.md.tmpl
@@ -102,6 +102,7 @@ Flaky tests are bugs. Investigate and fix them — never skip or retry blindly.
 - Do NOT run `git commit` without the focused proof for that coherent slice passing
 - Do NOT claim completion or merge without the full required proof passing on the frozen cumulative candidate
 - Do NOT run `git push` without a self-review
+- For a commit or push from a linked worktree, use a standalone `git -C <absolute-worktree> commit ...` or `git -C <absolute-worktree> push ...`; never rely only on the execution tool's `workdir`, because some Codex surfaces omit it from PreToolUse payloads.
 - These are enforced by hooks — violations are blocked automatically
 
 ## Self-Review

--- a/tests/test-skill.sh
+++ b/tests/test-skill.sh
@@ -547,6 +547,23 @@ test_sdlc_documents_incremental_completion_cadence() {
     fi
 }
 
+test_sdlc_exposes_linked_worktree_git_target_to_hooks() {
+    local file
+    local valid=true
+
+    for file in "$REPO_SDLC_SKILL" "$SHIPPED_SDLC_SKILL" "$SDLC_LOOP" "$AGENTS_BASELINE" "$AGENTS_TEMPLATE"; do
+        grep -Fq 'git -C <absolute-worktree>' "$file" || valid=false
+        grep -Eqi 'linked worktree.*(commit|push)|(commit|push).*linked worktree' "$file" || valid=false
+        grep -Eqi '(do not|never).*(rely|depend).*tool.*workdir|tool.*workdir.*(may|can).*(drop|omit|missing)' "$file" || valid=false
+    done
+
+    if [ "$valid" = "true" ]; then
+        pass "SDLC workflow exposes linked-worktree Git targets to PreToolUse hooks"
+    else
+        fail "SDLC workflow can hide linked-worktree Git targets in a dropped tool workdir"
+    fi
+}
+
 test_skill_manifest_exists
 test_plugin_skill_resolves_bundled_scripts_from_plugin_root
 test_plugin_skill_handles_legacy_standalone_install
@@ -567,6 +584,7 @@ test_sdlc_workflow_is_bounded_and_repairable
 test_sdlc_review_reuses_one_broad_proof
 test_sdlc_documents_bounded_dual_review
 test_sdlc_documents_incremental_completion_cadence
+test_sdlc_exposes_linked_worktree_git_target_to_hooks
 
 echo ""
 echo "=== Results: $PASSED passed, $FAILED failed ==="


### PR DESCRIPTION
Closes #85.

## What changed
- require explicit standalone `git -C <absolute-worktree> commit/push` in every shipped SDLC workflow layer
- explain that tool-level `workdir` may be absent from PreToolUse payloads
- add regression coverage across installer, repo skill, loop docs, and generated AGENTS guidance
- prepare package/plugin/docs for 0.7.37

## Proof
- focused skill/release/roadmap checks passed
- canonical proof suite: 11/11 passed
- exact candidate tree: `ecf682f89764fafd0f5bfedc276cec616cc3d403`
- bounded Sol High + Fable High final review: CERTIFIED in the initial round