### PR TITLE
docs: synchronize 1.0 release roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,52 +2,88 @@
 
 ## How to use this roadmap
 
-- GitHub issues are the source of truth for scope, acceptance criteria, milestones, and status.
+- GitHub issues are the source of truth for scope, acceptance criteria, milestone membership, and status.
+- `ROADMAP.md` is this repository's single ordered project backlog and cold-session resume contract.
 - The numbered order below is the project priority. The first open item is next unless the maintainer explicitly reorders the queue.
-- A GitHub milestone is a planned release; its issues are the work required for that release.
-- `ROADMAP.md` is this repository's single ordered project backlog. An optional generated `GOALS.md` may scope execution inside a consumer repo, but it never overrides this project's priority queue.
-- Reorder links here when priority changes, but keep implementation detail and completion evidence in the linked issue or pull request.
-- Every actionable item must have one issue owner. Pull requests reference or close that issue, and failing CI never merges.
+- A GitHub milestone is a planned release; its open issues are the work required before that release can close.
+- An optional generated `GOALS.md` may scope execution inside a consumer repo, but it never overrides this project's priority queue.
+- Remove completed issues from the queue, add every new actionable issue once, and keep every open issue assigned to a milestone.
+- Pull requests reference their owning issue. Failing proof, review, or required CI never merges.
+
+## Cold-session checkpoint — resume here
+
+- The active engineering slice is [#158](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/158) in `/private/tmp/codex-sdlc-issue158` on `fix/issue-158-reject-review-tools`.
+- Its staged candidate tree `f43b24de8058b9a97e8ac009b7718ccb66361b3b` passed focused proof and the canonical 11/11 proof, then correctly returned `NOT CERTIFIED`.
+- The blocking findings are candidate-born: detect real nested Claude `message.content[]` tool-use blocks, prevent a rejected event from becoming a clean result, and keep rejection classification ahead of timeout classification.
+- Add focused RED regressions for those behaviors, implement one bounded corrective slice, rerun focused proof, mint one fresh canonical proof, and run one bounded completion gate.
+- Do not edit, stage, clean, or merge the dirty root checkout. It contains unrelated historical work.
+- After #158 integrates, return to the frozen [#109](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/109) v4 pilot. Do not resume its obsolete v2 or v3 candidates.
+- Continue through the complete `1.0.0` block below. Do not start post-1.0 work while an earlier release blocker remains open.
 
 ## Current State
 
-- Current release candidate: `v0.7.38`, binding certified review evidence to one fixed-argv commit, push, PR-check, and exact integration boundary.
-- Current GitHub release after this candidate is published: [`v0.7.38`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.38).
-- Current npm release after this candidate is published: [`codex-sdlc-wizard@0.7.38`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.38).
-- Next release milestone: [`1.0.0 — Bounded autonomous delivery`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/2).
-- The ten-delivery cadence pilot is installed on `main`; its measurement issue remains open until the recorded evidence supports a permanent policy.
-- Real Windows Codex Desktop and CLI acceptance is the last hardware-dependent gate. Mac/Linux implementation and proof continue before that handoff.
+- Latest published GitHub release: [`v0.7.37`](https://github.com/BaseInfinity/codex-sdlc-wizard/releases/tag/v0.7.37).
+- Latest published npm release: [`codex-sdlc-wizard@0.7.37`](https://www.npmjs.com/package/codex-sdlc-wizard/v/0.7.37).
+- Development package metadata: `0.7.38`; it is not a published release.
+- Next major release: [`1.0.0 — Bounded autonomous delivery`](https://github.com/BaseInfinity/codex-sdlc-wizard/milestone/2).
+- The synchronized 1.0 milestone contains twelve open release issues and eleven completed issues as of 2026-08-17.
+- The release objective is bounded autonomous delivery: exact-candidate proof, terminating independent review, honest failures, one canonical workflow entry, trustworthy Windows behavior, real Windows acceptance, and immutable publish verification.
+- Real Windows Codex Desktop and CLI acceptance remains the final hardware-dependent gate before publish verification.
+- `1.0.0` is the next public release. Do not divert the release train into another 0.7.x feature batch.
 
 ## Priority queue
 
-1. **Make two-reviewer reconciliation direct and bounded** — [#116: independent review, verbatim cross-feed, one reconciliation, one answer](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/116) (`1.0.0`).
-2. **Bind final approval to the exact integrated candidate** — [#111: certify the precise tree that can reach the default branch](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/111) (`1.0.0`).
-3. **Require honest RED evidence without manufacturing fake tests** — [#115: scope TDD RED to writable behavior and explicit evidence exceptions](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/115) (`1.0.0`).
-4. **Measure the bounded incremental-review pilot** — [#109: record ten eligible deliveries and decide the permanent cadence empirically](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/109) (`1.0.0`).
-5. **Eliminate nondeterministic Windows proof cleanup** — [#92: fix access-denied proof-stamp teardown](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/92) (`1.0.0`).
-6. **Keep Windows review evidence honest** — [#93: detect WindowsApps PowerShell before trusting review validation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/93) (`1.0.0`).
-7. **Run the final real-Windows acceptance gate** — [#79: validate the 1.0 candidate in Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79) (`1.0.0`, human-required).
-8. **Publish and verify the aligned release** — [#88: publish `codex-sdlc-wizard` 1.0.0 to npm and GitHub](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88) (`1.0.0`, human-required where credentials require it).
-9. **Soak the released contract in real consumer repos** — [#112: collect daily post-1.0 feedback and make only proven fixes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/112) (`1.1.0`).
-10. **Preserve known-good behavior during upgrades** — [#84: adopt a stability contract for model and harness changes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/84) (`1.1.0`).
-11. **Finish the Sol High policy migration** — [#86: enforce Sol High unless the user explicitly overrides it](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/86) (`1.1.0`).
-12. **Audit generated instruction ownership** — [#95: reconcile `AGENTS.md` with current Codex guidance](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/95) (`1.1.0`).
-13. **Teach the issue-to-PR-to-release lifecycle** — [#100: enforce bounded issue, pull-request, milestone, and merge state](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/100) (`1.1.0`).
-14. **Make sibling harnesses coexist safely** — [#106: define shared-root ownership with `claude-sdlc-harness`](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/106) (`1.1.0`).
-15. **Add one read-only health entrypoint** — [#82: implement a Codex-native doctor flow with explicit repair](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82) (`1.1.0`).
-16. **Submit the proven release to the Plugins Directory** — [#66: complete the universal directory submission](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66) (`Distribution`).
-17. **Audit CI/CD for independent value** — [#108: remove duplicate work and retain only release-enforcing evidence](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/108) (`1.2.0`).
-18. **Detect release drift deterministically** — [#99: reconcile package, tag, release, and issue state](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/99) (`1.2.0`).
-19. **Timebox the cumulative upstream audit** — [#65: evaluate upstream v1.74.0 through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65) (`1.2.0`).
-20. **Reconcile the newest upstream release** — [#113: evaluate upstream SDLC Wizard v1.96.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/113) (`1.2.0`).
-21. **Keep release documentation impact-based** — [#105: update README/release docs and add stabilized demos when they materially help](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/105) (`1.3.0`).
-22. **Consolidate redundant proof documentation** — [#104: fold `PROVE-IT.md` into `TESTING.md` by default](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/104) (`1.3.0`).
-23. **Rename wizard to harness with a controlled migration** — [#101: apply the sibling-repo migration checklist without breaking consumers](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/101) (`1.3.0`).
-24. **Clean contributor attribution only through an explicit history operation** — [#107: remove bot attribution without risking repository history](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/107) (`1.3.0`, human-required).
-25. **Research a fast incremental lane** — [#114: evaluate GPT-5.3-Codex-Spark](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/114) (research backlog).
-26. **Benchmark optional model orchestration** — [#72: compare direct Sol/Luna driving with bounded Sol-to-Luna delegation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (research backlog).
-27. **Evaluate Fable before planning** — [#71: measure Fable as an optional planning advisor](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/71) (research backlog).
-28. **Research context-pressure policy** — [#77: measure compaction thresholds and subagent effects](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/77) (research backlog).
-29. **Evaluate another CLI host** — [#97: research a GitHub Copilot CLI adapter](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/97) (research backlog).
-30. **Revisit portable enforcement after host adapters stabilize** — [#58: compare a portable SDLC MCP server with per-host skills](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/58) (research backlog).
-31. **Consider a Copilot Studio surface last** — [#96: research a front end only after portable enforcement is justified](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/96) (research backlog).
+1. **Reject forbidden reviewer tool use immediately** — [#158: stop tool-free cross-model reviews when Claude invokes advisor](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/158) (`1.0.0`, P0, active).
+2. **Complete the measured bounded-correction pilot** — [#109: incremental corrective commits with a final whole-PR gate](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/109) (`1.0.0`, P0).
+3. **Make reviewer infrastructure state observable** — [#157: expose provider progress and distinguish invocation failure from verdict](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/157) (`1.0.0`).
+4. **Block executable Git configuration at delivery** — [#141: reject exec-capable Git config in exact-candidate commands](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/141) (`1.0.0`).
+5. **Separate confidence from defect severity** — [#131: require actionable reviewer remediation without conflating confidence](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/131) (`1.0.0`).
+6. **Retain concise failed-proof evidence** — [#124: preserve failed-test summaries when broad proof output truncates](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/124) (`1.0.0`).
+7. **Restore one canonical workflow entry** — [#127: remove duplicate global and repo-local `$sdlc` exposure](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/127) (`1.0.0`).
+8. **Make explicit updates one-step and agent-driven** — [#147: honor requests to update to the latest wizard](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/147) (`1.0.0`).
+9. **Eliminate nondeterministic Windows proof cleanup** — [#92: fix access-denied proof-stamp teardown](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/92) (`1.0.0`).
+10. **Keep Windows review evidence honest** — [#93: detect WindowsApps PowerShell before trusting review validation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/93) (`1.0.0`).
+11. **Run the final real-Windows acceptance gate** — [#79: validate the 1.0 candidate in Codex Desktop and CLI](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/79) (`1.0.0`, human-required).
+12. **Publish and verify the major release** — [#88: publish `codex-sdlc-wizard` 1.0.0 to npm and GitHub](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/88) (`1.0.0`, human-required where credentials require it).
+13. **Audit host-managed memory before premium rollout** — [#129: compare host memory with checked-in repository truth](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/129) (`1.1.0`).
+14. **Implement the premium Codex host lane** — [#128: Fable High plans/reviews and Sol High builds with one reconciliation](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/128) (`1.1.0`).
+15. **Finish the High-only planning and review policy** — [#86: preserve explicit implementation overrides](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/86) (`1.1.0`).
+16. **Make Fable review output evidence-first** — [#123: tighten cross-model review output](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/123) (`1.1.0`).
+17. **Preserve known-good behavior during upgrades** — [#84: adopt a stability contract for model and harness changes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/84) (`1.1.0`).
+18. **Classify self-targeting maintenance as SDLC work** — [#130: treat mutating setup, update, and repair commands honestly](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/130) (`1.1.0`).
+19. **Validate PowerShell policy before mutation** — [#153: reject invalid reviewer policy before updater writes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/153) (`1.1.0`).
+20. **Align skill metadata with evidence lanes** — [#154: make headings and descriptions honest](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/154) (`1.1.0`).
+21. **Add one read-only health entrypoint** — [#82: implement a Codex-native doctor flow with explicit repair](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/82) (`1.1.0`).
+22. **Audit generated instruction ownership** — [#95: reconcile `AGENTS.md` with current Codex guidance](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/95) (`1.1.0`).
+23. **Make sibling harnesses coexist safely** — [#106: define shared-root ownership with `claude-sdlc-harness`](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/106) (`1.1.0`).
+24. **Teach the issue-to-PR-to-release lifecycle** — [#100: enforce bounded issue, pull-request, milestone, and merge state](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/100) (`1.1.0`).
+25. **Support ordered multi-milestone goals** — [#151: continue across ordered milestones and hand off cleanup safely](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/151) (`1.1.0`).
+26. **Make terminal lifecycle state declarative** — [#136: reconcile exact status after merge](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/136) (`1.1.0`).
+27. **Add an opt-in progress dashboard** — [#135: show issue and milestone progress without claiming readiness](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/135) (`1.1.0`).
+28. **Preserve privacy in feedback attribution** — [#126: make source-repository attribution opt-in](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/126) (`1.1.0`).
+29. **Soak the released contract in real consumer repos** — [#112: collect daily post-1.0 feedback and make only proven fixes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/112) (`1.1.0`).
+30. **Measure adversarial refutation against bounded review** — [#138: compare cross-vendor review strategies](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/138) (`1.1.0`, research).
+31. **Research convergence-based termination** — [#132: compare convergence with fixed correction caps](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/132) (`1.1.0`, research).
+32. **Research a fast incremental model lane** — [#114: evaluate GPT-5.3-Codex-Spark](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/114) (`1.2.0`).
+33. **Benchmark optional worker orchestration** — [#72: compare direct Sol driving with bounded Luna workers](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/72) (`1.2.0`).
+34. **Research context-pressure policy** — [#77: measure compaction thresholds and worker effects](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/77) (`1.2.0`).
+35. **Submit the proven release to the Plugins Directory** — [#66: complete universal directory submission](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/66) (`Distribution`, human-required).
+36. **Research recurring post-1.0 distribution** — [#140: evaluate agent marketplaces and directories](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/140) (`Distribution`, research).
+37. **Audit CI/CD for independent value** — [#108: retain only release-enforcing evidence](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/108) (`1.3.0`).
+38. **Prove fast-first without weakening full-final** — [#139: evaluate a bounded CI tier](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/139) (`1.3.0`, research).
+39. **Detect release drift deterministically** — [#99: reconcile package, tag, release, and issue state](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/99) (`1.3.0`).
+40. **Timebox the cumulative upstream audit** — [#65: evaluate upstream v1.74.0 through v1.91.0](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/65) (`1.3.0`).
+41. **Reconcile upstream v1.96.0** — [#113: evaluate the newer SDLC Wizard release](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/113) (`1.3.0`).
+42. **Reconcile upstream v1.98.0** — [#160: translate applicable upstream changes](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/160) (`1.3.0`).
+43. **Keep release documentation impact-based** — [#105: add stabilized demos only when they materially help](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/105) (`1.4.0`).
+44. **Consolidate redundant proof documentation** — [#104: fold `PROVE-IT.md` into `TESTING.md` by default](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/104) (`1.4.0`).
+45. **Rename wizard to harness with a controlled migration** — [#101: apply the sibling-repo migration checklist safely](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/101) (`1.4.0`).
+46. **Clean contributor attribution only through an explicit history operation** — [#107: remove bot attribution without risking repository history](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/107) (`1.4.0`, human-required).
+47. **Research persistent Codex output style** — [#144: identify and measure the nearest supported mechanism](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/144) (`Research`, non-blocking).
+48. **Research DeepSeek Harness after 1.0** — [#142: evaluate portable plugin ideas](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/142) (`Research`, non-blocking).
+49. **Track the in-app Browser range-slider defect** — [#134: require observable native slider interaction](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/134) (`Research`, external-tooling, non-blocking).
+50. **Map the SDLC experience across Copilot tiers** — [#125: compare every Copilot host](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/125) (`Research`, non-blocking).
+51. **Identify the Microsoft-enterprise coding host** — [#122: prove the supported enterprise surface](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/122) (`Research`, human-required, non-blocking).
+52. **Evaluate another CLI host** — [#97: research a GitHub Copilot CLI adapter](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/97) (`Research`, non-blocking).
+53. **Revisit portable enforcement after host adapters stabilize** — [#58: compare a portable SDLC MCP server with per-host skills](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/58) (`Research`, non-blocking).
+54. **Consider a Copilot Studio surface last** — [#96: research a front end only after portable enforcement is justified](https://github.com/BaseInfinity/codex-sdlc-wizard/issues/96) (`Research`, human-required, non-blocking).

--- a/tests/test-roadmap.sh
+++ b/tests/test-roadmap.sh
@@ -8,7 +8,8 @@ REPO_DIR="$SCRIPT_DIR/.."
 ROADMAP="$REPO_DIR/ROADMAP.md"
 PACKAGE_JSON="$REPO_DIR/package.json"
 REPOSITORY_URL_REGEX='https://github[.]com/BaseInfinity/codex-sdlc-wizard'
-OPEN_ISSUES="58 65 66 71 72 77 79 82 84 86 88 92 93 95 96 97 99 100 101 104 105 106 107 108 109 111 112 113 114 115 116"
+OPEN_ISSUES="58 65 66 72 77 79 82 84 86 88 92 93 95 96 97 99 100 101 104 105 106 107 108 109 112 113 114 122 123 124 125 126 127 128 129 130 131 132 134 135 136 138 139 140 141 142 144 147 151 153 154 157 158 160"
+PUBLISHED_VERSION="0.7.37"
 PASSED=0
 FAILED=0
 
@@ -28,7 +29,7 @@ fail() {
 
 issue_line() {
     local issue_number="$1"
-    grep -nE "$REPOSITORY_URL_REGEX/issues/$issue_number([^0-9]|$)" "$ROADMAP" | cut -d: -f1 | head -n1 || true
+    priority_lines | grep -nE "$REPOSITORY_URL_REGEX/issues/$issue_number([^0-9]|$)" | cut -d: -f1 | head -n1 || true
 }
 
 roadmap_has_issue() {
@@ -51,6 +52,20 @@ priority_lines() {
 priority_has_issue() {
     local issue_number="$1"
     priority_lines | grep -Eq "$REPOSITORY_URL_REGEX/issues/$issue_number([^0-9]|$)"
+}
+
+test_issue_line_is_scoped_to_priority_queue() {
+    local actual
+    local expected
+
+    actual=$(issue_line 158)
+    expected=$(priority_lines | grep -nE "$REPOSITORY_URL_REGEX/issues/158([^0-9]|$)" | cut -d: -f1 | head -n1 || true)
+
+    if [ -n "$actual" ] && [ "$actual" = "$expected" ]; then
+        pass "Issue ordering is measured inside the priority queue"
+    else
+        fail "Issue ordering can be masked by links outside the priority queue"
+    fi
 }
 
 echo "=== Roadmap Tests ==="
@@ -83,15 +98,37 @@ test_roadmap_declares_order_as_priority() {
     fi
 }
 
-test_roadmap_states_current_release() {
+test_roadmap_states_release_boundary() {
     local package_version
+    local package_version_regex
+    local published_version_regex
     package_version=$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' "$PACKAGE_JSON" | head -n1)
+    package_version_regex=${package_version//./[.]}
+    published_version_regex=${PUBLISHED_VERSION//./[.]}
 
-    if grep -Eq "GitHub release.*${package_version}|${package_version}.*GitHub release" "$ROADMAP" &&
-       grep -Eq "npm.*${package_version}|${package_version}.*npm" "$ROADMAP"; then
-        pass "Roadmap states the package-aligned current release"
+    if grep -Eqi "published GitHub release.*${published_version_regex}|${published_version_regex}.*published GitHub release" "$ROADMAP" &&
+       grep -Eqi "published npm release.*${published_version_regex}|${published_version_regex}.*published npm release" "$ROADMAP" &&
+       grep -Eqi "development package.*${package_version_regex}|${package_version_regex}.*development package" "$ROADMAP" &&
+       grep -Eqi "next (public |major )?release.*1[.]0[.]0|1[.]0[.]0.*next (public |major )?release" "$ROADMAP"; then
+        pass "Roadmap distinguishes the published release, development package, and 1.0 target"
     else
-        fail "Roadmap does not state the package-aligned GitHub and npm release"
+        fail "Roadmap does not state the exact published/development/1.0 release boundary"
+    fi
+}
+
+test_roadmap_has_current_resume_checkpoint() {
+    local issue_158
+    local issue_109
+
+    issue_158=$(issue_line 158)
+    issue_109=$(issue_line 109)
+
+    if grep -Eq '^## Cold-session checkpoint' "$ROADMAP" &&
+       grep -Eqi '#158.*(active|resume|first)|(active|resume|first).*#158' "$ROADMAP" &&
+       [ -n "$issue_158" ] && [ -n "$issue_109" ] && [ "$issue_158" -lt "$issue_109" ]; then
+        pass "Roadmap gives a current #158-first cold-session checkpoint"
+    else
+        fail "Roadmap does not give the current #158-first cold-session checkpoint"
     fi
 }
 
@@ -158,7 +195,7 @@ test_roadmap_priority_section_contains_only_numbered_items() {
 test_roadmap_excludes_resolved_issues() {
     local issue_number
     local stale=0
-    local closed_issues="64 67 73 81 91 98 110"
+    local closed_issues="64 67 71 73 81 91 98 110 111 115 116 137 143 148"
 
     for issue_number in $closed_issues; do
         if roadmap_has_issue "$issue_number"; then
@@ -202,7 +239,7 @@ test_roadmap_head_order_matches_priority() {
     local previous=0
     local current
     local issue_number
-    local ordered_issues="116 111 115 109 92 93 79 88 112 84 86 95 100 106 82 66 108 99 65 113 105 104 101 107 114 72 71 77 97 58 96"
+    local ordered_issues="158 109 157 141 131 124 127 147 92 93 79 88 129 128 86 123 84 130 153 154 82 95 106 100 151 136 135 126 112 138 132 114 72 77 66 140 108 139 99 65 113 160 105 104 101 107 144 142 134 125 122 97 58 96"
 
     for issue_number in $ordered_issues; do
         current=$(issue_line "$issue_number")
@@ -271,8 +308,10 @@ test_roadmap_removes_stale_prose_sections() {
 }
 
 test_roadmap_exists
+test_issue_line_is_scoped_to_priority_queue
 test_roadmap_declares_order_as_priority
-test_roadmap_states_current_release
+test_roadmap_states_release_boundary
+test_roadmap_has_current_resume_checkpoint
 test_roadmap_links_post_merge_open_issue_snapshot
 test_roadmap_rejects_unknown_issue_links
 test_roadmap_excludes_resolved_issues


### PR DESCRIPTION
Refs #88. Synchronizes the complete GitHub milestone backlog, published-versus-development release state, and the current #158 to #109 cold-session checkpoint.